### PR TITLE
サンプルページとしてGitHubアカウントを検索する機能を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.10.6",
         "@emotion/server": "^11.10.0",
         "@mantine/core": "^5.10.4",
+        "@mantine/form": "^5.10.4",
         "@mantine/hooks": "^5.10.4",
         "@mantine/next": "^5.10.4",
         "@next/font": "13.1.6",
@@ -412,6 +413,18 @@
         "@mantine/hooks": "5.10.4",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@mantine/form": {
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-5.10.4.tgz",
+      "integrity": "sha512-gf/aNwvWzJwqo1C98yxLK0nJJxYIxYTI7nVQ/spFlaWY+arvXgybwPsdphxdo0j3aM4xJXjC52gDMme3gQrwNw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "klona": "^2.0.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@mantine/hooks": {
@@ -2737,8 +2750,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -3682,6 +3694,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -5690,6 +5710,15 @@
         "react-textarea-autosize": "8.3.4"
       }
     },
+    "@mantine/form": {
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-5.10.4.tgz",
+      "integrity": "sha512-gf/aNwvWzJwqo1C98yxLK0nJJxYIxYTI7nVQ/spFlaWY+arvXgybwPsdphxdo0j3aM4xJXjC52gDMme3gQrwNw==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "klona": "^2.0.5"
+      }
+    },
     "@mantine/hooks": {
       "version": "5.10.4",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-5.10.4.tgz",
@@ -7304,8 +7333,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -7998,6 +8026,11 @@
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.3"
       }
+    },
+    "klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="
     },
     "language-subtag-registry": {
       "version": "0.3.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-error-boundary": "^3.1.4",
-        "typescript": "4.9.4"
+        "typescript": "4.9.4",
+        "zod": "^3.20.6"
       },
       "devDependencies": {
         "@types/eslint": "^8.21.1",
@@ -5415,6 +5416,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -9265,6 +9274,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@emotion/react": "^11.10.6",
     "@emotion/server": "^11.10.0",
     "@mantine/core": "^5.10.4",
+    "@mantine/form": "^5.10.4",
     "@mantine/hooks": "^5.10.4",
     "@mantine/next": "^5.10.4",
     "@next/font": "13.1.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "^3.1.4",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "zod": "^3.20.6"
   },
   "devDependencies": {
     "@types/eslint": "^8.21.1",

--- a/src/api/client/fetch/gitHub.ts
+++ b/src/api/client/fetch/gitHub.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import type { FetchGitHubAccount } from '@/features';
+import { GitHubAccountNotFoundError, httpStatusCode } from '@/features';
+
+// https://api.github.com/users/USERNAME のResponseBody
+// 必要な項目だけ定義している
+type FetchGitHubAccountResponseBody = {
+  login: string;
+  avatar_url: string;
+};
+
+const fetchGitHubAccountResponseBodySchema = z.object({
+  login: z.string().min(1),
+  avatar_url: z.string().url(),
+});
+
+export const fetchGitHubAccount: FetchGitHubAccount = async (dto) => {
+  const headers: HeadersInit =
+    dto.accessToken != null
+      ? {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${dto.accessToken}`,
+        }
+      : { Accept: 'application/vnd.github+json' };
+
+  const options: RequestInit = {
+    method: 'GET',
+    mode: 'cors',
+    cache: 'no-cache',
+    headers,
+  };
+
+  const response = await fetch(
+    `https://api.github.com/users/${dto.name}`,
+    options
+  );
+
+  if (response.status !== httpStatusCode.ok) {
+    if (httpStatusCode.notFound) {
+      throw new GitHubAccountNotFoundError();
+    }
+  }
+
+  // fetchGitHubAccountResponseBodySchema.parse() に失敗した場合例外がThrowされるのでここで型アサーションを使っても型安全は保証されている
+  const responseBody =
+    (await response.json()) as FetchGitHubAccountResponseBody;
+
+  fetchGitHubAccountResponseBodySchema.parse(responseBody);
+
+  return {
+    name: responseBody.login,
+    avatarUrl: responseBody.avatar_url,
+  };
+};

--- a/src/components/ErrorFallback/ErrorMessage.tsx
+++ b/src/components/ErrorFallback/ErrorMessage.tsx
@@ -1,8 +1,9 @@
 import type { FC } from 'react';
 import { Alert } from '@mantine/core';
+import { GitHubAccountNotFoundError } from '@/features';
 
 const createDisplayErrorMessage = (error: Error) => {
-  if (error.name === 'GitHubAccountNotFoundError') {
+  if (error instanceof GitHubAccountNotFoundError) {
     return 'GitHubアカウントは見つかりませんでした。';
   }
 

--- a/src/components/GitHubAccountSearch/GitHubAccountCard.tsx
+++ b/src/components/GitHubAccountSearch/GitHubAccountCard.tsx
@@ -1,0 +1,18 @@
+import type { FC } from 'react';
+import { Avatar, Paper, Text } from '@mantine/core';
+import type { GitHubAccount } from '@/features';
+
+type Props = {
+  gitHubAccount: GitHubAccount;
+};
+
+export const GitHubAccountCard: FC<Props> = ({ gitHubAccount }) => {
+  return (
+    <Paper radius="md" withBorder p="lg">
+      <Avatar src={gitHubAccount.avatarUrl} size={120} radius={120} mx="auto" />
+      <Text align="center" size="lg" weight={500} mt="md">
+        {gitHubAccount.name}
+      </Text>
+    </Paper>
+  );
+};

--- a/src/components/GitHubAccountSearch/GitHubAccountSearch.tsx
+++ b/src/components/GitHubAccountSearch/GitHubAccountSearch.tsx
@@ -1,0 +1,54 @@
+import { useState, type FC } from 'react';
+import { TextInput, Button, Group, Box } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useErrorHandler } from 'react-error-boundary';
+import { fetchGitHubAccount } from '@/api/client/fetch/gitHub';
+import type { GitHubAccount } from '@/features';
+import { GitHubAccountCard } from './GitHubAccountCard';
+
+export const GitHubAccountSearch: FC = () => {
+  const form = useForm({
+    initialValues: { inputGitHubAccountName: 'keitakn' },
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [gitHubAccount, setGitHubAccount] = useState<GitHubAccount>();
+
+  const handleError = useErrorHandler();
+
+  const onSubmit = form.onSubmit(async (values) => {
+    try {
+      const inputGitHubAccountName = values.inputGitHubAccountName;
+
+      const fetchedGitHubAccount = await fetchGitHubAccount({
+        name: inputGitHubAccountName,
+      });
+
+      setGitHubAccount(fetchedGitHubAccount);
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+  return (
+    <>
+      <Box sx={{ maxWidth: 300 }} mx="auto">
+        <form method="post" onSubmit={onSubmit}>
+          <TextInput
+            withAsterisk
+            label="GitHubのAccount名を入力して下さい。"
+            {...form.getInputProps('inputGitHubAccountName')}
+          />
+          <Group position="right" mt="md">
+            <Button type="submit">Submit</Button>
+          </Group>
+        </form>
+        {gitHubAccount ? (
+          <GitHubAccountCard gitHubAccount={gitHubAccount} />
+        ) : (
+          ''
+        )}
+      </Box>
+    </>
+  );
+};

--- a/src/components/GitHubAccountSearch/index.ts
+++ b/src/components/GitHubAccountSearch/index.ts
@@ -1,0 +1,1 @@
+export { GitHubAccountSearch } from './GitHubAccountSearch';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { TitleText } from './TitleText';
+export { GitHubAccountSearch } from './GitHubAccountSearch';
 export { ErrorFallback } from './ErrorFallback';
 export { HeaderMenu } from './HeaderMenu';

--- a/src/features/gitHub/GitHubAccountNotFoundError.ts
+++ b/src/features/gitHub/GitHubAccountNotFoundError.ts
@@ -1,0 +1,11 @@
+export class GitHubAccountNotFoundError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/features/gitHub/gitHub.ts
+++ b/src/features/gitHub/gitHub.ts
@@ -1,0 +1,19 @@
+type GitHubAccountName = string;
+
+type GitHubAvatarUrl = string;
+
+type GitHubAccessToken = string;
+
+export type GitHubAccount = {
+  name: GitHubAccountName;
+  avatarUrl: GitHubAvatarUrl;
+};
+
+type FetchGitHubAccountDto = {
+  name: GitHubAccountName;
+  accessToken?: GitHubAccessToken;
+};
+
+export type FetchGitHubAccount = (
+  dto: FetchGitHubAccountDto
+) => Promise<GitHubAccount>;

--- a/src/features/gitHub/index.ts
+++ b/src/features/gitHub/index.ts
@@ -1,0 +1,2 @@
+export type { FetchGitHubAccount, GitHubAccount } from './gitHub';
+export { GitHubAccountNotFoundError } from './GitHubAccountNotFoundError';

--- a/src/features/httpStatusCode/httpStatusCode.ts
+++ b/src/features/httpStatusCode/httpStatusCode.ts
@@ -1,0 +1,28 @@
+// https://developer.mozilla.org/ja/docs/Web/HTTP/Status から必要なものを抜粋して定義
+export const httpStatusCode = {
+  ok: 200,
+  created: 201,
+  accepted: 202,
+  noContent: 204,
+  movedPermanently: 301,
+  found: 302,
+  temporaryRedirect: 307,
+  permanentRedirect: 308,
+  badRequest: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  notFound: 404,
+  methodNotAllowed: 405,
+  requestTimeout: 408,
+  conflict: 409,
+  gone: 409,
+  unprocessableEntity: 422,
+  locked: 423,
+  tooManyRequests: 429,
+  internalServerError: 500,
+  badGateway: 502,
+  serviceUnavailable: 503,
+} as const;
+
+export type HttpStatusCode =
+  (typeof httpStatusCode)[keyof typeof httpStatusCode];

--- a/src/features/httpStatusCode/index.ts
+++ b/src/features/httpStatusCode/index.ts
@@ -1,0 +1,2 @@
+export { httpStatusCode } from './httpStatusCode';
+export type { HttpStatusCode } from './httpStatusCode';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,1 +1,5 @@
 export { appUrls } from './url';
+export { GitHubAccountNotFoundError } from './gitHub';
+export type { GitHubAccount, FetchGitHubAccount } from './gitHub';
+export { httpStatusCode } from './httpStatusCode';
+export type { HttpStatusCode } from './httpStatusCode';

--- a/src/features/sample/index.ts
+++ b/src/features/sample/index.ts
@@ -1,0 +1,1 @@
+export { sampleFunc } from './sample';

--- a/src/features/sample/sample.ts
+++ b/src/features/sample/sample.ts
@@ -1,0 +1,3 @@
+export const sampleFunc = (x: number, y: number): number => {
+  return x + y;
+};

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,0 +1,8 @@
+import type { NextPage } from 'next';
+import { GitHubAccountSearchTemplate } from '@/templates';
+
+const SearchPage: NextPage = () => {
+  return <GitHubAccountSearchTemplate />;
+};
+
+export default SearchPage;

--- a/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.tsx
+++ b/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.tsx
@@ -1,0 +1,11 @@
+import type { FC } from 'react';
+import { GitHubAccountSearch } from '@/components';
+import { DefaultLayout } from '@/layouts';
+
+export const GitHubAccountSearchTemplate: FC = () => {
+  return (
+    <DefaultLayout>
+      <GitHubAccountSearch />
+    </DefaultLayout>
+  );
+};

--- a/src/templates/GitHubAccountSearchTemplate/index.ts
+++ b/src/templates/GitHubAccountSearchTemplate/index.ts
@@ -1,0 +1,1 @@
+export { GitHubAccountSearchTemplate } from './GitHubAccountSearchTemplate';

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,0 +1,1 @@
+export { GitHubAccountSearchTemplate } from './GitHubAccountSearchTemplate';


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/5

# この PR で対応する範囲 / この PR で対応しない範囲

- Mantine を使ってGItHubアカウントを検索する為の機能が実装されている事

# Storybook の URL、 スクリーンショット

![success](https://user-images.githubusercontent.com/11032365/219684105-3dd0c249-43ec-41f2-9f08-61da45d374a1.png)

![Error](https://user-images.githubusercontent.com/11032365/219684163-e25e6666-7a3a-41cd-972c-958127784a44.png)

![Error2](https://user-images.githubusercontent.com/11032365/219686086-e96e1ddf-f844-4a68-90df-d49e9f9b943c.png)

# 変更点概要

サンプルページとしてGitHubアカウントを検索する機能を実装しました。

https://timelogger-web-git-feature-issue5add-sample-page-timelogger.vercel.app/search

この機能はテストコードやStorybookの導入の為に作成したサンプル機能です。

なので正式な開発がある程度進んだ時点で削除する予定です。

今回の対応で以下のPackageを追加しています。

- Formの作成を行いたいので `@mantine/form` を追加
- バリデーションや型ガードに必須なPackage `zod` を追加

このPackageに関しては実際の機能を開発する際にも必要になるので、無駄にはなりません。

# レビュアーに重点的にチェックして欲しい点

## レビューについて
情報共有の為、レビュアーに設定させて頂いております。

しばらくは開発が出来る状態までプロジェクトを整備している状況です。

お時間がありましたら、目を通して頂く程度の温度感で問題ありません。

※ 初期構築が完了した時点でフロントエンドメンバーには別途説明会の機会を作らせて頂きます。

# 補足情報

特になし