### PR TITLE
CI用のworkflowを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  build:
+    name: Test And Linter
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# timelogger-web
+
+[![ci](https://github.com/commew/timelogger-web/actions/workflows/ci.yml/badge.svg)](https://github.com/commew/timelogger-web/actions/workflows/ci.yml)
+
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/8

# この PR で対応する範囲 / この PR で対応しない範囲

- https://github.com/commew/timelogger-web/issues/8 の完了の定義に記載してある通り `main` ブランチにPRを出した時とマージされた時にCIが実行されるようになっている事

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

CI用のworkflowを追加。

CIでやっている具体的な内容は以下の通りです。

- Linterの実行を行い、ESLintのエラーやPrettierのエラーが残っている場合はworkflowを失敗させる
- Jestによるテストを実行して失敗しているテストが1件でもあった場合はworkflowを失敗させる

CI用のworkflowが通っていない場合、PRのマージを禁止する設定も追加済です。

# レビュアーに重点的にチェックして欲しい点

## レビューについて
情報共有の為、レビュアーに設定させて頂いております。

しばらくは開発が出来る状態までプロジェクトを整備している状況です。

お時間がありましたら、目を通して頂く程度の温度感で問題ありません。

※ 初期構築が完了した時点でフロントエンドメンバーには別途説明会の機会を作らせて頂きます。

# 補足情報

特になし