### PR TITLE
Storybook上でMSW（MockServiceWorker）を利用出来る設定を追加

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,4 +11,5 @@ module.exports = {
   core: {
     builder: '@storybook/builder-webpack5',
   },
+  staticDirs: ['../public'],
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,9 @@
+import { initialize, mswDecorator } from 'msw-storybook-addon';
+
+initialize();
+
+export const decorators = [mswDecorator];
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "jest": "^29.4.3",
         "jest-environment-jsdom": "^29.4.3",
         "msw": "^1.0.1",
+        "msw-storybook-addon": "^1.7.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.4",
         "storybook-addon-next": "^1.7.2",
@@ -21225,6 +21226,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.7.0.tgz",
+      "integrity": "sha512-G/cYj7Z8NuyFbMsdVJRr17flWed8J7CmKTSPNXmuK65W6uILpqNDpXJC7KVRhOg7lUFR5Hmqwcq6z8Mow/wu5A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.0.0",
+        "is-node-process": "^1.0.1"
+      },
+      "peerDependencies": {
+        "msw": ">=0.35.0 <1.0.0"
       }
     },
     "node_modules/msw/node_modules/chalk": {
@@ -44440,6 +44454,16 @@
           "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
+      }
+    },
+    "msw-storybook-addon": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.7.0.tgz",
+      "integrity": "sha512-G/cYj7Z8NuyFbMsdVJRr17flWed8J7CmKTSPNXmuK65W6uILpqNDpXJC7KVRhOg7lUFR5Hmqwcq6z8Mow/wu5A==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.0.0",
+        "is-node-process": "^1.0.1"
       }
     },
     "multipipe": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "jest": "^29.4.3",
     "jest-environment-jsdom": "^29.4.3",
     "msw": "^1.0.1",
+    "msw-storybook-addon": "^1.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.4",
     "storybook-addon-next": "^1.7.2",

--- a/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.stories.tsx
+++ b/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.stories.tsx
@@ -1,0 +1,47 @@
+import type { ComponentStoryObj } from '@storybook/react';
+import { rest } from 'msw';
+import {
+  mockFetchGitHubAccount,
+  mockFetchGitHubAccountUnexpectedResponseBody,
+  mockNotFoundError,
+} from '@/mocks';
+import { GitHubAccountSearchTemplate } from '@/templates';
+
+const story = {
+  component: GitHubAccountSearchTemplate,
+};
+
+export default story;
+
+type Story = ComponentStoryObj<typeof GitHubAccountSearchTemplate>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get('https://api.github.com/users/*', mockFetchGitHubAccount),
+      ],
+    },
+  },
+};
+
+export const ShowGitHubAccountNotFoundError: Story = {
+  parameters: {
+    msw: {
+      handlers: [rest.get('https://api.github.com/users/*', mockNotFoundError)],
+    },
+  },
+};
+
+export const ShowUnexpectedResponseBodyError: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get(
+          'https://api.github.com/users/*',
+          mockFetchGitHubAccountUnexpectedResponseBody
+        ),
+      ],
+    },
+  },
+};


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/7

# この PR で対応する範囲 / この PR で対応しない範囲

- Storybook上でMSW（MockServiceWorker）が利用出来るようになっている事

# Storybook の URL、 スクリーンショット

![storybook](https://user-images.githubusercontent.com/11032365/220011744-e2998184-2c49-4dc3-97c1-60553b011c34.png)

# 変更点概要

Storybook上でMSW（MockServiceWorker）を利用可能にする `msw-storybook-addon` を導入しました。

テスト時に利用しているMockを使ってGitHubAPIへの通信が発生するComponentのStoryを追加しました。

（参考）https://zenn.dev/rabbit/articles/dd9b04940b93fe

# レビュアーに重点的にチェックして欲しい点

## レビューについて
情報共有の為、レビュアーに設定させて頂いております。

しばらくは開発が出来る状態までプロジェクトを整備している状況です。

お時間がありましたら、目を通して頂く程度の温度感で問題ありません。

※ 初期構築が完了した時点でフロントエンドメンバーには別途説明会の機会を作らせて頂きます。

# 補足情報

特になし