### PR TITLE
コミット毎にchromaticにStorybookをデプロイする為のworkflowを追加

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,27 @@
+name: chromatic
+
+on: push
+
+jobs:
+  chromatic-deployment:
+    name: Deploy Storybook to chromatic
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.AUTH_TOKEN_FOR_GITHUB_PACKAGES }}
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # timelogger-web
 
 [![ci](https://github.com/commew/timelogger-web/actions/workflows/ci.yml/badge.svg)](https://github.com/commew/timelogger-web/actions/workflows/ci.yml)
+[![chromatic](https://github.com/commew/timelogger-web/actions/workflows/chromatic.yml/badge.svg)](https://github.com/commew/timelogger-web/actions/workflows/chromatic.yml)
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/9

# この PR で対応する範囲 / この PR で対応しない範囲

- コミット毎にchromaticにStorybookをデプロイする為のworkflowが追加されている事

# Storybook の URL、 スクリーンショット

https://63d52217f1430a5ad69846cd-ezppgdmumu.chromatic.com/?path=/story/templates-githubaccountsearchtemplate--default

# 変更点概要

PRタイトルの通りで、コミット毎にchromaticにStorybookをデプロイする為のworkflowを追加しました。

概要は以下の記事を参照して下さい。

https://zenn.dev/keitakn/articles/storybook-deploy-to-chromatic

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし