### PR TITLE
GoogleTagManagerの設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/src/components/GoogleTagManager/GoogleTagManager.tsx
+++ b/src/components/GoogleTagManager/GoogleTagManager.tsx
@@ -1,0 +1,23 @@
+import { type FC } from 'react';
+import Script from 'next/script';
+import { type GoogleTagManagerId } from '@/features';
+
+type Props = {
+  googleTagManagerId: GoogleTagManagerId;
+};
+
+export const GoogleTagManager: FC<Props> = ({ googleTagManagerId }) => (
+  <Script
+    id="gtm"
+    strategy="afterInteractive"
+    dangerouslySetInnerHTML={{
+      __html: `
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','${googleTagManagerId}');
+      `,
+    }}
+  />
+);

--- a/src/components/GoogleTagManager/index.ts
+++ b/src/components/GoogleTagManager/index.ts
@@ -1,0 +1,1 @@
+export { GoogleTagManager } from './GoogleTagManager';

--- a/src/features/googleTagManagerId/googleTagManagerId.ts
+++ b/src/features/googleTagManagerId/googleTagManagerId.ts
@@ -1,0 +1,21 @@
+export type GoogleTagManagerId = `GTM-${string}`;
+
+const isGoogleTagManagerId = (value: unknown): value is GoogleTagManagerId => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const startPosition = 0;
+
+  const endPosition = 4;
+
+  return value.slice(startPosition, endPosition) === 'GTM-';
+};
+
+export const getNullableGoogleTagManagerId = (): GoogleTagManagerId | null => {
+  if (isGoogleTagManagerId(process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID)) {
+    return process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID;
+  }
+
+  return null;
+};

--- a/src/features/googleTagManagerId/index.ts
+++ b/src/features/googleTagManagerId/index.ts
@@ -1,0 +1,2 @@
+export type { GoogleTagManagerId } from './googleTagManagerId';
+export { getNullableGoogleTagManagerId } from './googleTagManagerId';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -3,4 +3,6 @@ export { GitHubAccountNotFoundError } from './gitHub';
 export type { GitHubAccount, FetchGitHubAccount } from './gitHub';
 export { httpStatusCode } from './httpStatusCode';
 export type { HttpStatusCode } from './httpStatusCode';
+export type { GoogleTagManagerId } from './googleTagManagerId';
+export { getNullableGoogleTagManagerId } from './googleTagManagerId';
 export { sampleFunc } from './sample';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,10 @@
 import { MantineProvider } from '@mantine/core';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { getNullableGoogleTagManagerId } from '@/features';
+import { GoogleTagManager } from '@/components/GoogleTagManager';
+
+const googleTagManagerId = getNullableGoogleTagManagerId();
 
 const App = ({ Component, pageProps }: AppProps): JSX.Element => {
   return (
@@ -21,6 +25,11 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => {
           colorScheme: 'light',
         }}
       >
+        {googleTagManagerId !== null ? (
+          <GoogleTagManager googleTagManagerId={googleTagManagerId} />
+        ) : (
+          ''
+        )}
         <Component {...pageProps} />
       </MantineProvider>
     </>


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/28

# この PR で対応する範囲 / この PR で対応しない範囲

GoogleTagManager（以下GTMと略す）の設定が完了して、Google Analytics（以下GAと略す）上にデータが送信される状態になっている事。

# Storybook の URL、 スクリーンショット

## GA上にデータが送信されている事を確認済

![GA](https://user-images.githubusercontent.com/11032365/222620516-78f341ad-457b-4736-b1f2-1eba3f3e715d.png)

## VercelにGTMのIDを環境変数として追加済

![Vercel](https://user-images.githubusercontent.com/11032365/222620545-465f307b-9d02-4b2f-803e-3c5699507c3b.png)

# 変更点概要

GoogleTagManager用のComponentを作成してNext.jsのCustomAppComponentから読み込むように設定。

スクリーンショットにもあるようにGA上にデータが送信されている事も確認済です。

ローカルで開発する際にデータが送信されないように環境変数 `NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID` が存在しない場合はGoogleTagManager用のComponentを読み込まないようにしています。

ローカルでGAの検証をしたい場合は `.env` を生成して `NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID` を設定する必要があります。

```
NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-XXXXXXX
```

# レビュアーに重点的にチェックして欲しい点

## レビューについて
情報共有の為、レビュアーに設定させて頂いております。

しばらくは開発が出来る状態までプロジェクトを整備している状況です。

お時間がありましたら、目を通して頂く程度の温度感で問題ありません。

※ 初期構築が完了した時点でフロントエンドメンバーには別途説明会の機会を作らせて頂きます。

# 補足情報

インラインコメントに記載してあります。