### PR TITLE
isOidcProviderのテストをテンプレートリテラルを使った形にリファクタリング

### DIFF
--- a/src/features/__tests__/oidc/isOidcProvider.spec.ts
+++ b/src/features/__tests__/oidc/isOidcProvider.spec.ts
@@ -1,14 +1,23 @@
 import { isOidcProvider } from '@/features';
 
+type TestTable = {
+  arg: unknown;
+  expected: boolean;
+};
+
 describe('src/features/auth/oidc.ts isOidcProvider Test Cases', () => {
-  it.each([
-    [true, 'google'],
-    [false, 'amazon'],
-    [false, 1],
-    [false, {}],
-    [false, null],
-    [false, undefined],
-  ])('returns %p when the input is %p', (expected, input) => {
-    expect(isOidcProvider(input)).toBe(expected);
-  });
+  it.each`
+    arg          | expected
+    ${'google'}  | ${true}
+    ${'amazon'}  | ${false}
+    ${1}         | ${false}
+    ${{}}        | ${false}
+    ${null}      | ${false}
+    ${undefined} | ${false}
+  `(
+    'should returns $expected when the input is $arg',
+    ({ arg, expected }: TestTable) => {
+      expect(isOidcProvider(arg)).toBe(expected);
+    }
+  );
 });


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/36

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/commew/timelogger-web/issues/36 の完了の定義を満たす実装はこのPRの内で全て実施する。

# Storybook の URL、 スクリーンショット

UI変更は発生していません。

# 変更点概要

`isOidcProvider ` のテストコード内のTestTableを視覚的に分かりやすい形にする為、テンプレートリテラルを使った形にリファクタリングしました。

以下はわざとテストを失敗させた例です。

 `should returns true when the input is null` というメッセージを見ると分かるようにテスト失敗時の引数と期待値を表示出来ているので、どのテストが失敗したか視覚的に理解しやすくなっています。

```
> timelogger-web@0.1.0 test
> jest

info  - Loaded env from /Users/myuser/gitrepos/timelogger-web/.env
 FAIL  src/features/__tests__/oidc/isOidcProvider.spec.ts
  ● src/features/auth/oidc.ts isOidcProvider Test Cases › should returns true when the input is null

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      18 |     'should returns $expected when the input is $arg',
      19 |     ({ arg, expected }: TestTable) => {
    > 20 |       expect(isOidcProvider(arg)).toBe(expected);
         |                                   ^
      21 |     }
      22 |   );
      23 | });

      at toBe (src/features/__tests__/oidc/isOidcProvider.spec.ts:20:35)

 PASS  src/components/TitleText/__tests__/TitleText.spec.tsx
 PASS  src/api/client/fetch/__tests__/gitHub/fetchGitHubAccount.spec.ts
 PASS  src/features/__tests__/sample/sample.spec.ts

Test Suites: 1 failed, 3 passed, 4 total
Tests:       1 failed, 10 passed, 11 total
Snapshots:   0 total
Time:        0.807 s, estimated 1 s
Ran all test suites.
zsh: exit 1     npm run test
```

# レビュアーに重点的にチェックして欲しい点

## レビューについて
情報共有の為、レビュアーに設定させて頂いております。

しばらくは開発が出来る状態までプロジェクトを整備している状況です。

お時間がありましたら、目を通して頂く程度の温度感で問題ありません。

※ 初期構築が完了した時点でフロントエンドメンバーには別途説明会の機会を作らせて頂きます。

# 補足情報

インラインコメントに記載。