### PR TITLE
✨ #42 サイドバーコンポーネントの追加

### DIFF
--- a/src/components/HeaderNavigation/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation/HeaderNavigation.tsx
@@ -27,7 +27,7 @@ export const HeaderNavigation: FC = () => {
   const { classes } = useStyles();
 
   return (
-    <Header height={60} mb={60} px={60} className={classes.header}>
+    <Header height={60} mb={20} px={60} className={classes.header}>
       <div className={classes.inner}>
         <MantineLogo size={28} />
         <Group spacing={4} pl={30}>

--- a/src/components/SideBar/SideBar.stories.tsx
+++ b/src/components/SideBar/SideBar.stories.tsx
@@ -1,0 +1,12 @@
+import type { ComponentStoryObj } from '@storybook/react';
+import { SideBar } from './SideBar';
+
+const story = {
+  component: SideBar,
+};
+
+export default story;
+
+type Story = ComponentStoryObj<typeof SideBar>;
+
+export const Default: Story = {};

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+import type { FC } from 'react';
+import {
+  Group,
+  Box,
+  Collapse,
+  Navbar,
+  UnstyledButton,
+  createStyles,
+  NavLink,
+} from '@mantine/core';
+import { IconChevronUp, IconChevronDown, IconHome } from '@tabler/icons-react';
+
+const useStyles = createStyles((theme) => ({
+  button: {
+    fontWeight: 500,
+    display: 'block',
+    width: '100%',
+    padding: `${theme.spacing.xs} ${theme.spacing.md}`,
+    color: theme.black,
+    fontSize: theme.fontSizes.sm,
+
+    '&:hover': {
+      backgroundColor: theme.colors.gray[0],
+      color: theme.black,
+    },
+  },
+  chevron: {
+    transition: 'transform 200ms ease',
+  },
+  navbar: {
+    backgroundColor: theme.white,
+    paddingBottom: 0,
+    borderRightWidth: 0,
+    width: '30%',
+  },
+}));
+
+type Category = Readonly<{
+  id: number;
+  name: string;
+}>;
+
+type CategoryGroup = Readonly<{
+  id: number;
+  name: string;
+  categories: Category[];
+}>;
+
+// ここがAPIのレスポンス結果に置き変わるイメージ。
+const mockGroups: CategoryGroup[] = [
+  {
+    id: 1,
+    name: 'グループ名1',
+    categories: [
+      {
+        id: 1,
+        name: 'カテゴリ名1',
+      },
+      {
+        id: 2,
+        name: 'カテゴリ名2',
+      },
+      {
+        id: 3,
+        name: 'カテゴリ名3',
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: 'グループ名2',
+    categories: [
+      {
+        id: 4,
+        name: 'カテゴリ名4',
+      },
+      {
+        id: 5,
+        name: 'カテゴリ名5',
+      },
+      {
+        id: 6,
+        name: 'カテゴリ名6',
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: 'グループ名3',
+    categories: [
+      {
+        id: 7,
+        name: 'カテゴリ名7',
+      },
+      {
+        id: 8,
+        name: 'カテゴリ名8',
+      },
+      {
+        id: 9,
+        name: 'カテゴリ名9',
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: 'グループ名4',
+    categories: [
+      {
+        id: 10,
+        name: 'カテゴリ名10',
+      },
+      {
+        id: 11,
+        name: 'カテゴリ名11',
+      },
+      {
+        id: 12,
+        name: 'カテゴリ名12',
+      },
+    ],
+  },
+];
+
+export const SideBar: FC = () => {
+  const { classes, theme } = useStyles();
+  const [opened, setOpened] = useState<Record<string, boolean>>({});
+  const ChevronIcon = theme.dir === 'ltr' ? IconChevronDown : IconChevronUp;
+
+  return (
+    <Navbar height={800} p="md" className={classes.navbar}>
+      <Navbar.Section grow>
+        {mockGroups.map((group) => (
+          <Group key={group.id}>
+            <UnstyledButton
+              onClick={() => {
+                setOpened((prevOpened) => ({
+                  ...prevOpened,
+                  [group.id]: !prevOpened[group.id],
+                }));
+              }}
+              className={classes.button}
+            >
+              <Group position="apart" spacing={0}>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  <ChevronIcon
+                    className={classes.chevron}
+                    size="1rem"
+                    stroke={1.5}
+                    style={{
+                      transform: opened[group.id]
+                        ? `rotate(${theme.dir !== 'rtl' ? -180 : -180}deg)`
+                        : 'none',
+                    }}
+                  />
+                  <Box ml="2rem">{group.name}</Box>
+                </Box>
+              </Group>
+            </UnstyledButton>
+            <Collapse in={opened[group.id]} pl={'1.25rem'}>
+              <Group>
+                <NavLink
+                  icon={
+                    <IconHome
+                      size="1rem"
+                      stroke={1.5}
+                      color={theme.colors.blue[6]}
+                    />
+                  }
+                  label="カテゴリ名"
+                ></NavLink>
+                <NavLink
+                  icon={
+                    <IconHome
+                      size="1rem"
+                      stroke={1.5}
+                      color={theme.colors.blue[6]}
+                    />
+                  }
+                  label="カテゴリ名カテゴリ名カテゴリ名カテゴリ名カテゴリ名カテゴリ名"
+                ></NavLink>
+                <NavLink
+                  icon={
+                    <IconHome
+                      size="1rem"
+                      stroke={1.5}
+                      color={theme.colors.blue[6]}
+                    />
+                  }
+                  label="カテゴリ名"
+                ></NavLink>
+              </Group>
+            </Collapse>
+          </Group>
+        ))}
+        <NavLink
+          icon={
+            <IconHome size="1rem" stroke={1.5} color={theme.colors.blue[6]} />
+          }
+          label="カテゴリ名"
+        ></NavLink>
+        <NavLink
+          icon={
+            <IconHome size="1rem" stroke={1.5} color={theme.colors.blue[6]} />
+          }
+          label="カテゴリ名"
+        ></NavLink>
+      </Navbar.Section>
+    </Navbar>
+  );
+};

--- a/src/components/SideBar/__tests__/SideBar.spec.tsx
+++ b/src/components/SideBar/__tests__/SideBar.spec.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import { SideBar } from '@/components';
+
+// まだ参照しているデータがmockなので、一旦、テストケースをskipしてます。
+// 確認したい観点だけ定義してます。
+describe('src/components/SideBar/SideBar.tsx TestCases', () => {
+  it.skip('should display the link label', () => {
+    render(<SideBar />);
+  });
+  it.skip('toggles group categories on click', () => {
+    render(<SideBar />);
+  });
+});

--- a/src/components/SideBar/index.ts
+++ b/src/components/SideBar/index.ts
@@ -1,0 +1,1 @@
+export { SideBar } from './SideBar';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,3 +4,4 @@ export { ErrorFallback } from './ErrorFallback';
 export { HeaderMenu } from './HeaderMenu';
 export { GoogleLoginButton } from './GoogleLoginButton';
 export { HeaderNavigation } from './HeaderNavigation';
+export { SideBar } from './SideBar';

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -1,9 +1,8 @@
 import type { FC, ReactNode } from 'react';
-import { Container } from '@mantine/core';
+import { Container, createStyles } from '@mantine/core';
 import Head from 'next/head';
 import { ErrorBoundary } from 'react-error-boundary';
 import { HeaderMenu, TitleText, HeaderNavigation, SideBar } from '@/components';
-import styles from '@/styles/defaultLayout.module.css';
 import { ErrorFallback } from '@/components/ErrorFallback/ErrorFallback';
 
 type Props = {
@@ -18,27 +17,41 @@ const onError = (error: Error, info: { componentStack: string }) => {
 
 const title = 'Time Logger（仮）';
 
+const useStyles = createStyles(() => ({
+  layoutWrapper: {
+    display: 'flex',
+    width: '100%',
+  },
+  mainContent: {
+    width: '70%',
+  },
+}));
+
 // eslint-disable-next-line max-lines-per-function
-export const DefaultLayout: FC<Props> = ({ children }) => (
-  <>
-    <Head>
-      <title>Time Logger（仮）</title>
-      <meta charSet="utf-8" />
-      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-      <meta name="robots" content="noindex , nofollow" />
-    </Head>
-    <HeaderNavigation></HeaderNavigation>
-    <Container size="xl">
-      <div className={styles.layoutWrapper}>
-        <SideBar></SideBar>
-        <div className={styles.mainContent}>
-          <TitleText title={title} />
-          <HeaderMenu />
-          <ErrorBoundary FallbackComponent={ErrorFallback} onError={onError}>
-            {children}
-          </ErrorBoundary>
+export const DefaultLayout: FC<Props> = ({ children }) => {
+  const { classes } = useStyles();
+
+  return (
+    <>
+      <Head>
+        <title>Time Logger（仮）</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+        <meta name="robots" content="noindex , nofollow" />
+      </Head>
+      <HeaderNavigation></HeaderNavigation>
+      <Container size="xl">
+        <div className={classes.layoutWrapper}>
+          <SideBar></SideBar>
+          <div className={classes.mainContent}>
+            <TitleText title={title} />
+            <HeaderMenu />
+            <ErrorBoundary FallbackComponent={ErrorFallback} onError={onError}>
+              {children}
+            </ErrorBoundary>
+          </div>
         </div>
-      </div>
-    </Container>
-  </>
-);
+      </Container>
+    </>
+  );
+};

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -2,7 +2,8 @@ import type { FC, ReactNode } from 'react';
 import { Container } from '@mantine/core';
 import Head from 'next/head';
 import { ErrorBoundary } from 'react-error-boundary';
-import { HeaderMenu, TitleText, HeaderNavigation } from '@/components';
+import { HeaderMenu, TitleText, HeaderNavigation, SideBar } from '@/components';
+import styles from '@/styles/defaultLayout.module.css';
 import { ErrorFallback } from '@/components/ErrorFallback/ErrorFallback';
 
 type Props = {
@@ -27,12 +28,17 @@ export const DefaultLayout: FC<Props> = ({ children }) => (
       <meta name="robots" content="noindex , nofollow" />
     </Head>
     <HeaderNavigation></HeaderNavigation>
-    <Container my="md">
-      <TitleText title={title} />
-      <HeaderMenu />
-      <ErrorBoundary FallbackComponent={ErrorFallback} onError={onError}>
-        {children}
-      </ErrorBoundary>
+    <Container size="xl">
+      <div className={styles.layoutWrapper}>
+        <SideBar></SideBar>
+        <div className={styles.mainContent}>
+          <TitleText title={title} />
+          <HeaderMenu />
+          <ErrorBoundary FallbackComponent={ErrorFallback} onError={onError}>
+            {children}
+          </ErrorBoundary>
+        </div>
+      </div>
     </Container>
   </>
 );

--- a/src/styles/defaultLayout.module.css
+++ b/src/styles/defaultLayout.module.css
@@ -1,8 +1,0 @@
-.layoutWrapper {
-  display: flex;
-  width: 100%;
-}
-
-.mainContent {
-  width: 70%;
-}

--- a/src/styles/defaultLayout.module.css
+++ b/src/styles/defaultLayout.module.css
@@ -1,0 +1,8 @@
+.layoutWrapper {
+  display: flex;
+  width: 100%;
+}
+
+.mainContent {
+  width: 70%;
+}


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/42

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/commew/timelogger-web/issues/42 の完了の定義を満たしていること。

APIのレスポンス結果を渡して表示するところは一旦、mockのdataを用意して固定値で表示するようにしてます。APIのレスポンス結果に変える対応は別PRで対応します。
テストコードも一旦、mockを使用しているため、観点だけ記載してます。APIの結果反映時に別PRで対応します。


# Storybook の URL、 スクリーンショット

<img width="759" alt="スクリーンショット 2023-04-09 22 00 44" src="https://user-images.githubusercontent.com/36589062/230774132-b9adc2e4-bd84-4e97-92c7-856fd4de9108.png">
<img width="845" alt="スクリーンショット 2023-04-09 22 00 53" src="https://user-images.githubusercontent.com/36589062/230774124-f3c58a08-0d50-4481-b1f0-e209567726cf.png">

https://user-images.githubusercontent.com/36589062/230774109-1614a93a-cfa2-4751-b9d3-2b8dc04e86f7.mov



# 変更点概要

サイドバーコンポーネントを作成しました。

<img width="1399" alt="スクリーンショット 2023-04-17 10 13 58" src="https://user-images.githubusercontent.com/36589062/232356377-9337ca88-cc89-4d0d-8043-9da3bb91a9fe.png">



# レビュアーに重点的にチェックして欲しい点

PR内の各箇所にコメント残してますのでそこら辺を重点的に見てもらえればと思います。

# 補足情報

特になし。
