### PR TITLE
アカウント関連のAPIの設計を追加

### DIFF
--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -9,150 +9,30 @@ servers:
   - url: 'http://localhost:5757'
     description: local
 paths:
-  '/users/{userId}':
-    parameters:
-      - schema:
-          type: integer
-        name: userId
-        in: path
-        required: true
-        description: Id of an existing user.
-    get:
-      summary: Get User Info by User ID
-      tags: []
-      responses:
-        '200':
-          description: User Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                Get User Alice Smith:
-                  value:
-                    id: 142
-                    firstName: Alice
-                    lastName: Smith
-                    email: alice.smith@gmail.com
-                    dateOfBirth: '1997-10-31'
-                    emailVerified: true
-                    signUpDate: '2019-08-24'
-        '404':
-          description: User Not Found
-      operationId: get-users-userId
-      description: Retrieve the information of the user with the matching user ID.
-    patch:
-      summary: Update User Information
-      operationId: patch-users-userId
-      responses:
-        '200':
-          description: User Updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                Updated User Rebecca Baker:
-                  value:
-                    id: 13
-                    firstName: Rebecca
-                    lastName: Baker
-                    email: rebecca@gmail.com
-                    dateOfBirth: '1985-10-02'
-                    emailVerified: false
-                    createDate: '2019-08-24'
-        '404':
-          description: User Not Found
-        '409':
-          description: Email Already Taken
-      description: Update the information of an existing user.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                firstName:
-                  type: string
-                lastName:
-                  type: string
-                email:
-                  type: string
-                  description: 'If a new email is given, the user''s email verified property will be set to false.'
-                dateOfBirth:
-                  type: string
-            examples:
-              Update First Name:
-                value:
-                  firstName: Rebecca
-              Update Email:
-                value:
-                  email: rebecca@gmail.com
-              Update Last Name & Date of Birth:
-                value:
-                  lastName: Baker
-                  dateOfBirth: '1985-10-02'
-        description: Patch user properties to update.
-  /user:
-    post:
-      summary: Create New User
-      operationId: post-user
-      responses:
-        '200':
-          description: User Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                New User Bob Fellow:
-                  value:
-                    id: 12
-                    firstName: Bob
-                    lastName: Fellow
-                    email: bob.fellow@gmail.com
-                    dateOfBirth: '1996-08-24'
-                    emailVerified: false
-                    createDate: '2020-11-18'
-        '400':
-          description: Missing Required Information
-        '409':
-          description: Email Already Taken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                firstName:
-                  type: string
-                lastName:
-                  type: string
-                email:
-                  type: string
-                dateOfBirth:
-                  type: string
-                  format: date
-              required:
-                - firstName
-                - lastName
-                - email
-                - dateOfBirth
-            examples:
-              Create User Bob Fellow:
-                value:
-                  firstName: Bob
-                  lastName: Fellow
-                  email: bob.fellow@gmail.com
-                  dateOfBirth: '1996-08-24'
-        description: Post the necessary fields for the API to create a new user.
-      description: Create a new user.
   /accounts:
     get:
       summary: Your GET endpoint
       tags: []
-      responses: {}
-      operationId: get-accounts
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+              examples:
+                ExampleSuccess:
+                  value:
+                    id: 1
+                    name: NekoKoneko
+                    openIdProvider:
+                      - sub: '10769150350006150715113082367'
+                        provider: google
+      operationId: getAccounts
+      description: アカウントを1件取得する。アカウントの識別子はAuthorizationに指定したJWT形式のトークンの物が利用される。
+      parameters: []
+      security:
+        - Authorization: []
     post:
       summary: ''
       operationId: postAccounts
@@ -162,12 +42,24 @@ paths:
           content:
             application/json:
               schema:
+                $ref: '#/components/schemas/Account'
+              examples:
+                ExampleSuccess:
+                  value:
+                    id: 1
+                    name: NekoKoneko
+                    openIdProvider:
+                      - sub: '10769150350006150715113082367'
+                        provider: google
+            application/xml:
+              schema:
                 type: object
                 properties: {}
       description: アカウント登録を行うAPI
       parameters:
         - schema:
             type: string
+            example: Basic YWRtaW5Vc2VyOnBhc3N3b3JkMTIzNA==
           in: header
           name: Authorization
           description: 'Authorization: Basic の形で送信する'
@@ -185,46 +77,6 @@ paths:
         description: ''
 components:
   schemas:
-    User:
-      title: User
-      type: object
-      description: ''
-      examples:
-        - id: 142
-          firstName: Alice
-          lastName: Smith
-          email: alice.smith@gmail.com
-          dateOfBirth: '1997-10-31'
-          emailVerified: true
-          signUpDate: '2019-08-24'
-      properties:
-        id:
-          type: integer
-          description: Unique identifier for the given user.
-        firstName:
-          type: string
-        lastName:
-          type: string
-        email:
-          type: string
-          format: email
-        dateOfBirth:
-          type: string
-          format: date
-          example: '1997-10-31'
-        emailVerified:
-          type: boolean
-          description: Set to true if the user's email has been verified.
-        createDate:
-          type: string
-          format: date
-          description: The date that the user was created.
-      required:
-        - id
-        - firstName
-        - lastName
-        - email
-        - emailVerified
     Account:
       title: account
       x-stoplight:
@@ -283,3 +135,8 @@ components:
           provider: google
         - sub: lineid99999999999999999999999
           provider: line
+  securitySchemes:
+    Authorization:
+      type: http
+      scheme: bearer
+      description: Bearer + 半角スペース + JWT形式のトークンで指定する。

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -147,6 +147,42 @@ paths:
                   dateOfBirth: '1996-08-24'
         description: Post the necessary fields for the API to create a new user.
       description: Create a new user.
+  /accounts:
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses: {}
+      operationId: get-accounts
+    post:
+      summary: ''
+      operationId: postAccounts
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+      description: アカウント登録を行うAPI
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Authorization
+          description: 'Authorization: Basic の形で送信する'
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpenIdProvider'
+            examples:
+              Example 1:
+                value:
+                  sub: '10769150350006150715113082367'
+                  provider: google
+        description: ''
 components:
   schemas:
     User:
@@ -189,3 +225,61 @@ components:
         - lastName
         - email
         - emailVerified
+    Account:
+      title: account
+      x-stoplight:
+        id: d81ba26a96905
+      type: object
+      description: アカウント
+      examples:
+        - id: 1
+          name: NekoKoneko
+          openIdProvider:
+            - sub: '10769150350006150715113082367'
+              provider: google
+        - id: 2
+          name: MyCat
+          openIdProvider:
+            - sub: '999999999999999999999999999'
+              provider: google
+            - sub: lineid99999999999999999999999
+              provider: line
+      properties:
+        id:
+          type: number
+          minimum: 1
+          description: アカウントの識別子
+        name:
+          type: string
+          description: アカウント名
+        openIdProviders:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenIdProvider'
+      required:
+        - id
+        - name
+        - openIdProviders
+    OpenIdProvider:
+      title: OpenIdProvider
+      x-stoplight:
+        id: e1ambjwj1ixhm
+      type: object
+      description: 登録・ログイン時に利用するOpenIdProvider
+      properties:
+        sub:
+          type: string
+          example: '10769150350006150715113082367'
+          description: OpenIdProviderのユーザー識別子
+        provider:
+          type: string
+          pattern: /^(google|line|apple|facebook)$/
+          description: 'OpenIdProviderの種類を表す .e.g. google, line'
+      required:
+        - sub
+        - provider
+      examples:
+        - sub: '10769150350006150715113082367'
+          provider: google
+        - sub: lineid99999999999999999999999
+          provider: line

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -28,6 +28,28 @@ paths:
                     openIdProvider:
                       - sub: '10769150350006150715113082367'
                         provider: google
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleAuthenticated:
+                  value:
+                    type: UNAUTHENTICATED
+                    title: Account is not authenticated.
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleInternalServerError:
+                  value:
+                    type: INTERNAL_SERVER_ERROR
+                    title: Internal Server Error.
       operationId: getAccounts
       description: アカウントを1件取得する。アカウントの識別子はAuthorizationに指定したJWT形式のトークンの物が利用される。
       parameters: []
@@ -55,6 +77,55 @@ paths:
               schema:
                 type: object
                 properties: {}
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleAccountAlreadyRegistered:
+                  value:
+                    type: BAD_REQUEST
+                    title: Account is already registered.
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleAuthenticated:
+                  value:
+                    type: UNAUTHENTICATED
+                    title: Basic Authentication parameters are incorrect.
+        '422':
+          description: Unprocessable Entity (WebDAV)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationProblemDetails'
+              examples:
+                ExampleValidationError:
+                  value:
+                    type: UNPROCESSABLE_ENTITY
+                    title: Unprocessable Entity.
+                    invalidParams:
+                      - name: sub
+                        reason: sub is required.
+                      - name: provider
+                        reason: invalid provider format.
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleInternalServerError:
+                  value:
+                    type: INTERNAL_SERVER_ERROR
+                    title: Internal Server Error.
       description: アカウント登録を行うAPI
       parameters:
         - schema:
@@ -135,6 +206,61 @@ components:
           provider: google
         - sub: lineid99999999999999999999999
           provider: line
+    ProblemDetails:
+      title: ProblemDetails
+      x-stoplight:
+        id: h75jw6u0neq18
+      type: object
+      properties:
+        type:
+          type: string
+          example: UNAUTHENTICATED
+          description: RFC7807を参照。エラーの種類を表す文字列。
+        title:
+          type: string
+          example: Account is not authenticated.
+          description: RFC7807 エラーのタイトル。
+      required:
+        - type
+        - title
+    ValidationProblemDetails:
+      title: ValidationProblemDetails
+      x-stoplight:
+        id: y6a6qh2azlqdi
+      type: object
+      properties:
+        type:
+          type: string
+          description: RFC7807を参照。エラーの種類を表す文字列。
+          pattern: /^UNPROCESSABLE_ENTITY$/
+        title:
+          type: string
+          description: RFC7807 エラーのタイトル。
+          pattern: /^Unprocessable Entity\.$/
+        invalidParams:
+          type: array
+          description: RFC7807 バリデーションエラーの詳細情報
+          items:
+            $ref: '#/components/schemas/InvalidParam'
+      required:
+        - type
+        - title
+        - invalidParams
+    InvalidParam:
+      title: InvalidParam
+      x-stoplight:
+        id: o53o6997g1shv
+      type: object
+      properties:
+        name:
+          type: string
+          description: バリデーションエラーとなったキー名が格納される
+        reason:
+          type: string
+          description: バリデーションエラーが発生した理由が格納される
+      required:
+        - name
+        - reason
   securitySchemes:
     Authorization:
       type: http

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -176,7 +176,6 @@ paths:
       parameters:
         - schema:
             type: string
-            example: Basic YWRtaW5Vc2VyOnBhc3N3b3JkMTIzNA==
           in: header
           name: Authorization
           description: 'Authorization: Basic の形で送信する'

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -1,0 +1,191 @@
+openapi: 3.1.0
+x-stoplight:
+  id: i8i3l2jkf1i6e
+info:
+  title: timmew
+  version: '1.0'
+  description: 'https://timmew.commew.net で利用するREST API'
+servers:
+  - url: 'http://localhost:5757'
+    description: local
+paths:
+  '/users/{userId}':
+    parameters:
+      - schema:
+          type: integer
+        name: userId
+        in: path
+        required: true
+        description: Id of an existing user.
+    get:
+      summary: Get User Info by User ID
+      tags: []
+      responses:
+        '200':
+          description: User Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              examples:
+                Get User Alice Smith:
+                  value:
+                    id: 142
+                    firstName: Alice
+                    lastName: Smith
+                    email: alice.smith@gmail.com
+                    dateOfBirth: '1997-10-31'
+                    emailVerified: true
+                    signUpDate: '2019-08-24'
+        '404':
+          description: User Not Found
+      operationId: get-users-userId
+      description: Retrieve the information of the user with the matching user ID.
+    patch:
+      summary: Update User Information
+      operationId: patch-users-userId
+      responses:
+        '200':
+          description: User Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              examples:
+                Updated User Rebecca Baker:
+                  value:
+                    id: 13
+                    firstName: Rebecca
+                    lastName: Baker
+                    email: rebecca@gmail.com
+                    dateOfBirth: '1985-10-02'
+                    emailVerified: false
+                    createDate: '2019-08-24'
+        '404':
+          description: User Not Found
+        '409':
+          description: Email Already Taken
+      description: Update the information of an existing user.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                  description: 'If a new email is given, the user''s email verified property will be set to false.'
+                dateOfBirth:
+                  type: string
+            examples:
+              Update First Name:
+                value:
+                  firstName: Rebecca
+              Update Email:
+                value:
+                  email: rebecca@gmail.com
+              Update Last Name & Date of Birth:
+                value:
+                  lastName: Baker
+                  dateOfBirth: '1985-10-02'
+        description: Patch user properties to update.
+  /user:
+    post:
+      summary: Create New User
+      operationId: post-user
+      responses:
+        '200':
+          description: User Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              examples:
+                New User Bob Fellow:
+                  value:
+                    id: 12
+                    firstName: Bob
+                    lastName: Fellow
+                    email: bob.fellow@gmail.com
+                    dateOfBirth: '1996-08-24'
+                    emailVerified: false
+                    createDate: '2020-11-18'
+        '400':
+          description: Missing Required Information
+        '409':
+          description: Email Already Taken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                dateOfBirth:
+                  type: string
+                  format: date
+              required:
+                - firstName
+                - lastName
+                - email
+                - dateOfBirth
+            examples:
+              Create User Bob Fellow:
+                value:
+                  firstName: Bob
+                  lastName: Fellow
+                  email: bob.fellow@gmail.com
+                  dateOfBirth: '1996-08-24'
+        description: Post the necessary fields for the API to create a new user.
+      description: Create a new user.
+components:
+  schemas:
+    User:
+      title: User
+      type: object
+      description: ''
+      examples:
+        - id: 142
+          firstName: Alice
+          lastName: Smith
+          email: alice.smith@gmail.com
+          dateOfBirth: '1997-10-31'
+          emailVerified: true
+          signUpDate: '2019-08-24'
+      properties:
+        id:
+          type: integer
+          description: Unique identifier for the given user.
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+          format: email
+        dateOfBirth:
+          type: string
+          format: date
+          example: '1997-10-31'
+        emailVerified:
+          type: boolean
+          description: Set to true if the user's email has been verified.
+        createDate:
+          type: string
+          format: date
+          description: The date that the user was created.
+      required:
+        - id
+        - firstName
+        - lastName
+        - email
+        - emailVerified

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -11,7 +11,7 @@ servers:
 paths:
   /accounts:
     get:
-      summary: 'アカウントを1件取得する'
+      summary: アカウントを1件取得する
       tags:
         - accounts
       responses:
@@ -29,6 +29,11 @@ paths:
                     openIdProvider:
                       - sub: '10769150350006150715113082367'
                         provider: google
+          headers:
+            Request-Id:
+              schema:
+                type: string
+              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
         '401':
           description: Unauthorized
           content:
@@ -40,6 +45,11 @@ paths:
                   value:
                     type: UNAUTHENTICATED
                     title: Account is not authenticated.
+          headers:
+            Request-Id:
+              schema:
+                type: string
+              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
         '500':
           description: Internal Server Error
           content:
@@ -51,13 +61,23 @@ paths:
                   value:
                     type: INTERNAL_SERVER_ERROR
                     title: Internal Server Error.
+          headers:
+            Request-Id:
+              schema:
+                type: string
+              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
       operationId: getAccounts
       description: アカウントを1件取得する。アカウントの識別子はAuthorizationに指定したJWT形式のトークンの物が利用される。
-      parameters: []
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Request-Id
+          description: ユニークなID、これを指定した場合はレスポンス時にそのまま返ってくる
       security:
         - Authorization: []
     post:
-      summary: 'アカウント登録を行う'
+      summary: アカウント登録を行う
       operationId: postAccounts
       responses:
         '201':
@@ -78,6 +98,11 @@ paths:
               schema:
                 type: object
                 properties: {}
+          headers:
+            Request-Id:
+              schema:
+                type: string
+              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
         '400':
           description: Bad Request
           content:
@@ -89,6 +114,11 @@ paths:
                   value:
                     type: BAD_REQUEST
                     title: Account is already registered.
+          headers:
+            Request-Id:
+              schema:
+                type: string
+              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
         '401':
           description: Unauthorized
           content:
@@ -100,6 +130,11 @@ paths:
                   value:
                     type: UNAUTHENTICATED
                     title: Basic Authentication parameters are incorrect.
+          headers:
+            Request-Id:
+              schema:
+                type: string
+              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
         '422':
           description: Unprocessable Entity (WebDAV)
           content:
@@ -116,6 +151,11 @@ paths:
                         reason: sub is required.
                       - name: provider
                         reason: invalid provider format.
+          headers:
+            Request-Id:
+              schema:
+                type: string
+              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
         '500':
           description: Internal Server Error
           content:
@@ -127,6 +167,11 @@ paths:
                   value:
                     type: INTERNAL_SERVER_ERROR
                     title: Internal Server Error.
+          headers:
+            Request-Id:
+              schema:
+                type: string
+              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
       description: アカウント登録を行うAPI
       parameters:
         - schema:
@@ -136,6 +181,11 @@ paths:
           name: Authorization
           description: 'Authorization: Basic の形で送信する'
           required: true
+        - schema:
+            type: string
+          in: header
+          name: Request-Id
+          description: ユニークなID、これを指定した場合はレスポンス時にそのまま返ってくる
       requestBody:
         content:
           application/json:

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -200,7 +200,7 @@ paths:
 components:
   schemas:
     Account:
-      title: account
+      title: Account
       x-stoplight:
         id: d81ba26a96905
       type: object
@@ -276,30 +276,43 @@ components:
       required:
         - type
         - title
+      description: エラー発生時に返す構造体（RFC7807を参考にしている）
+      examples:
+        - type: UNAUTHENTICATED
+          title: Account is not authenticated.
     ValidationProblemDetails:
       title: ValidationProblemDetails
       x-stoplight:
         id: y6a6qh2azlqdi
       type: object
+      additionalProperties: false
+      description: バリデーションエラーの発生時に返す構造体（RFC7807を参考にしている）
       properties:
         type:
           type: string
           description: RFC7807を参照。エラーの種類を表す文字列。
-          pattern: /^UNPROCESSABLE_ENTITY$/
+          example: UNPROCESSABLE_ENTITY
         title:
           type: string
           description: RFC7807 エラーのタイトル。
-          pattern: /^Unprocessable Entity\.$/
+          example: Unprocessable Entity.
         invalidParams:
           type: array
           description: RFC7807 バリデーションエラーの詳細情報
           items:
             $ref: '#/components/schemas/InvalidParam'
-      additionalProperties: false
       required:
         - type
         - title
         - invalidParams
+      examples:
+        - type: UNPROCESSABLE_ENTITY
+          title: Unprocessable Entity.
+          invalidParams:
+            - name: email
+              reason: email is required.
+            - name: phoneNumber
+              reason: phoneNumber is required.
     InvalidParam:
       title: InvalidParam
       x-stoplight:
@@ -316,6 +329,10 @@ components:
       required:
         - name
         - reason
+      examples:
+        - name: email
+          reason: email is required.
+      description: バリデーションエラーの詳細を表す（RFC7807を参考にしている）
   securitySchemes:
     Authorization:
       type: http

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -189,6 +189,11 @@ components:
         id: e1ambjwj1ixhm
       type: object
       description: 登録・ログイン時に利用するOpenIdProvider
+      examples:
+        - sub: '10769150350006150715113082367'
+          provider: google
+        - sub: lineid99999999999999999999999
+          provider: line
       properties:
         sub:
           type: string
@@ -196,16 +201,10 @@ components:
           description: OpenIdProviderのユーザー識別子
         provider:
           type: string
-          pattern: /^(google|line|apple|facebook)$/
           description: 'OpenIdProviderの種類を表す .e.g. google, line'
       required:
         - sub
         - provider
-      examples:
-        - sub: '10769150350006150715113082367'
-          provider: google
-        - sub: lineid99999999999999999999999
-          provider: line
     ProblemDetails:
       title: ProblemDetails
       x-stoplight:

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -33,7 +33,7 @@ paths:
             Request-Id:
               schema:
                 type: string
-              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
+              description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
         '401':
           description: Unauthorized
           content:
@@ -49,7 +49,7 @@ paths:
             Request-Id:
               schema:
                 type: string
-              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
+              description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
         '500':
           description: Internal Server Error
           content:
@@ -65,7 +65,7 @@ paths:
             Request-Id:
               schema:
                 type: string
-              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
+              description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
       operationId: getAccounts
       description: アカウントを1件取得する。アカウントの識別子はAuthorizationに指定したJWT形式のトークンの物が利用される。
       parameters:
@@ -73,7 +73,7 @@ paths:
             type: string
           in: header
           name: Request-Id
-          description: ユニークなID、これを指定した場合はレスポンス時にそのまま返ってくる
+          description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
       security:
         - Authorization: []
     post:
@@ -102,7 +102,7 @@ paths:
             Request-Id:
               schema:
                 type: string
-              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
+              description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
         '400':
           description: Bad Request
           content:
@@ -118,7 +118,7 @@ paths:
             Request-Id:
               schema:
                 type: string
-              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
+              description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
         '401':
           description: Unauthorized
           content:
@@ -134,7 +134,7 @@ paths:
             Request-Id:
               schema:
                 type: string
-              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
+              description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
         '422':
           description: Unprocessable Entity (WebDAV)
           content:
@@ -155,7 +155,7 @@ paths:
             Request-Id:
               schema:
                 type: string
-              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
+              description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
         '500':
           description: Internal Server Error
           content:
@@ -171,7 +171,7 @@ paths:
             Request-Id:
               schema:
                 type: string
-              description: ユニークなID、リクエスト時に指定された場合はそのまま返す
+              description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
       description: アカウント登録を行うAPI
       parameters:
         - schema:
@@ -185,7 +185,7 @@ paths:
             type: string
           in: header
           name: Request-Id
-          description: ユニークなID、これを指定した場合はレスポンス時にそのまま返ってくる
+          description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
       requestBody:
         content:
           application/json:

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -180,6 +180,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenIdProvider'
+      additionalProperties: false
       required:
         - id
         - name
@@ -203,6 +204,7 @@ components:
         provider:
           type: string
           description: 'OpenIdProviderの種類を表す .e.g. google, line'
+      additionalProperties: false
       required:
         - sub
         - provider
@@ -220,6 +222,7 @@ components:
           type: string
           example: Account is not authenticated.
           description: RFC7807 エラーのタイトル。
+      additionalProperties: false
       required:
         - type
         - title
@@ -242,6 +245,7 @@ components:
           description: RFC7807 バリデーションエラーの詳細情報
           items:
             $ref: '#/components/schemas/InvalidParam'
+      additionalProperties: false
       required:
         - type
         - title
@@ -258,6 +262,7 @@ components:
         reason:
           type: string
           description: バリデーションエラーが発生した理由が格納される
+      additionalProperties: false
       required:
         - name
         - reason

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -95,7 +95,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
               examples:
-                ExampleAuthenticated:
+                ExampleUnAuthenticated:
                   value:
                     type: UNAUTHENTICATED
                     title: Basic Authentication parameters are incorrect.

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -12,7 +12,8 @@ paths:
   /accounts:
     get:
       summary: Your GET endpoint
-      tags: []
+      tags:
+        - accounts
       responses:
         '200':
           description: OK

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -26,7 +26,7 @@ paths:
                   value:
                     id: 1
                     name: NekoKoneko
-                    openIdProvider:
+                    openIdProviders:
                       - sub: '10769150350006150715113082367'
                         provider: google
           headers:
@@ -91,7 +91,7 @@ paths:
                   value:
                     id: 1
                     name: NekoKoneko
-                    openIdProvider:
+                    openIdProviders:
                       - sub: '10769150350006150715113082367'
                         provider: google
             application/xml:
@@ -207,12 +207,12 @@ components:
       examples:
         - id: 1
           name: NekoKoneko
-          openIdProvider:
+          openIdProviders:
             - sub: '10769150350006150715113082367'
               provider: google
         - id: 2
           name: MyCat
-          openIdProvider:
+          openIdProviders:
             - sub: '999999999999999999999999999'
               provider: google
             - sub: lineid99999999999999999999999

--- a/src/docs/reference/openapi.yaml
+++ b/src/docs/reference/openapi.yaml
@@ -11,7 +11,7 @@ servers:
 paths:
   /accounts:
     get:
-      summary: Your GET endpoint
+      summary: 'アカウントを1件取得する'
       tags:
         - accounts
       responses:
@@ -57,7 +57,7 @@ paths:
       security:
         - Authorization: []
     post:
-      summary: ''
+      summary: 'アカウント登録を行う'
       operationId: postAccounts
       responses:
         '201':


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/48

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/commew/timelogger-web/issues/48 の完了の定義にある通り以下の2つのAPIの設計を対応しました

- アカウント登録を行うAPI
- アカウントを取得するAPI

MockServerの起動やTypeScriptの型定義を生成する課題は以下のissueで対応予定ですので、このPRでは実施しません。

- https://github.com/commew/timelogger-web/issues/50
- https://github.com/commew/timelogger-web/issues/51

# Storybook の URL、 スクリーンショット

UI変更はないのでなし。

# 変更点概要

アカウント関連のAPIの設計を追加しました。

OpenAPIを利用しており `src/docs/reference/openapi.yaml` にAPI定義を追加してあります。

https://stoplight.io/studio を利用して作成しました。

下記にそれぞれのAPIのリクエスト・レスポンスのサンプルを追加してあります。

## サンプルリクエスト・レスポンス

https://stoplight.io/studio で `src/docs/reference/openapi.yaml`  を開くと MockServerが `http://127.0.0.1:3100` で起動しますので動作確認はこちらで行いました。

`Prefer` Headerを追加する事で任意のサンプルを返すようになります。

### アカウント登録

#### 正常系

```
curl -v \
-X POST \
-H "Prefer: code=201, example=ExampleSuccess" \
-H "Content-Type: application/json" \
-H "Authorization: Basic YWRtaW5Vc2VyOnBhc3N3b3JkMTIzNA==" \
-d '
{
  "sub": "99999999999999999999999999999",
  "provider": "google"
}
' \
http://127.0.0.1:3100/accounts | jq
```

`HTTP/1.1 201 Created`

```json
{
  "id": 1,
  "name": "NekoKoneko",
  "openIdProvider": [
    {
      "sub": "10769150350006150715113082367",
      "provider": "google"
    }
  ]
}
```

#### 異常系（認証エラー）

```
curl -v \
-X POST \
-H "Prefer: code=401, example=ExampleUnAuthenticated" \
-H "Content-Type: application/json" \
-H "Authorization: Basic YWRtaW5Vc2VyOnBhc3N3b3JkMTIzNA==" \
-d '
{
  "sub": "99999999999999999999999999999",
  "provider": "google"
}
' \
http://127.0.0.1:3100/accounts | jq
```

`HTTP/1.1 401 Unauthorized`

```json
{
  "type": "UNAUTHENTICATED",
  "title": "Basic Authentication parameters are incorrect."
}
```

#### バリデーションエラー

```
curl -v \
-X POST \
-H "Prefer: code=422, example=ExampleValidationError" \
-H "Content-Type: application/json" \
-H "Authorization: Basic YWRtaW5Vc2VyOnBhc3N3b3JkMTIzNA==" \
-d '
{
  "sub": "99999999999999999999999999999",
  "provider": "google"
}
' \
http://127.0.0.1:3100/accounts | jq
```

`HTTP/1.1 422 Unprocessable Entity`

```
{
  "type": "UNPROCESSABLE_ENTITY",
  "title": "Unprocessable Entity.",
  "invalidParams": [
    {
      "name": "sub",
      "reason": "sub is required."
    },
    {
      "name": "provider",
      "reason": "invalid provider format."
    }
  ]
}
```

### アカウント取得

#### 正常系

```
curl -v \
-H "Prefer: code=200, example=ExampleSuccess" \
-H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMDMxMjM2MjYxNjQzODE2MjQ1OTMiLCJwcm92aWRlciI6Imdvb2dsZSIsImV4cCI6MTY4MzczMTMyMywianRpIjoiMzU2N2RiMjctMzNkZS00MjE3LThjOWYtNTg4YWI1ZDA3YWRkIiwiaWF0IjoxNjgxMTM5Mzk2fQ.qbCDlBuENt_QdGKPIY4LZNtkroOTTIF2y8bhelmpjOw" \
http://127.0.0.1:3100/accounts | jq
```

`HTTP/1.1 401 Unauthorized`

#### 異常系（認証エラー）

```
{
  "type": "UNAUTHENTICATED",
  "title": "Account is not authenticated."
}
```

## OpenAPIの設計方針

あまり厳密にルールを定めている訳ではないですが、基本方針を以下に記載します。

- 必須パラメータには `required` を必ず使う
- null は基本的に不許可（TypeScriptの型定義を扱う際にnull許可プロパティがあると扱いにくいので）
- tag は必ず設計する（APIが増えてくるとこれがないと見にくいので）
- コードジェネレーターを使う時に必須になる為、 operationId は必ず設定（これはHTTPメソッド + リソース名で機械的に命名しています）
- `additionalProperties` は `false` に設定する（予期せぬ値が入ってこないように、これはGUIで付与出来ないので直接yamlを触る必要がある）

これらのルールに関しては [【OpenAPI】Stoplight Studioを活用して快適＆高速にAPI定義を書く方法｜Offers Tech Blog](https://zenn.dev/offers/articles/20220530-openapi_stoplight) を参考にしました。

ちなみにAPIのエラーフォーマットは [RFC7807](https://tex2e.github.io/rfc-translater/html/rfc7807.html) をベースにしています。[ぼくのかんがえたさいきょうの API エラーレスポンスのフォーマット](https://zenn.dev/ryamakuchi/articles/d7c932afc57e30) という記事を参考にしました

# レビュアーに重点的にチェックして欲しい点

アカウント登録、アカウント取得API、OpenAPIの設計方針に問題がないかご確認をお願いします。

GitHubで見ていてもイメージが付きにくいと思うので、何かOpenAPIを閲覧出来るエディタ等で見たほうが分かりやすいかと思います。

※ https://stoplight.io/studio をダウンロードして開いて頂くで問題ありません。

# 補足情報

インラインコメントをご確認下さい。