### PR TITLE
アカウント作成APIをコールする為の関数を実装

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,6 +39,7 @@ GOOGLE_OIDC_CLIENT_ID=GoogleのOpenIDConnectのクライアントID
 GOOGLE_OIDC_CLIENT_SECRET=GoogleのOpenIDConnectのクライアントシークレット
 NEXTAUTH_URL=http://localhost:5656
 NEXTAUTH_SECRET=十分に長い文字列
+BACKEND_API_BASE_URL=http://localhost:5757
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=設定は必須ではないですがGA等のデバッグを行いたい場合はVercelの値を参照
 NEXT_PUBLIC_APP_URL=http://localhost:5656
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -40,6 +40,8 @@ GOOGLE_OIDC_CLIENT_SECRET=GoogleのOpenIDConnectのクライアントシーク�
 NEXTAUTH_URL=http://localhost:5656
 NEXTAUTH_SECRET=十分に長い文字列
 BACKEND_API_BASE_URL=http://localhost:5757
+API_BASIC_AUTH_USER=Vercelの値を参照
+API_BASIC_AUTH_PASSWORD=Vercelの値を参照
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=設定は必須ではないですがGA等のデバッグを行いたい場合はVercelの値を参照
 NEXT_PUBLIC_APP_URL=http://localhost:5656
 ```

--- a/src/README.md
+++ b/src/README.md
@@ -47,6 +47,14 @@ Component の内部で React hooks を利用する事は問題ありません。
 
 Component 名と同様のディレクトリ名を作成して `index.ts` を使って外部公開が必要な Component だけを export するようにします。
 
+## api
+
+API に通信を行う関数を格納します。
+
+現状は `src/api/fetch/` しか存在しませんが `fetch` の部分には HTTP クライアントが入ります。
+
+実装する際は `features/` 配下に関数のインターフェースを実装して、それを利用する形で実装します。
+
 ## constants
 
 アプリケーション全体で利用する定数を格納します。

--- a/src/api/server/fetch/__tests__/account/createAccount.spec.ts
+++ b/src/api/server/fetch/__tests__/account/createAccount.spec.ts
@@ -1,0 +1,83 @@
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { createAccount } from '@/api/server/fetch/account';
+import {
+  getBackendApiUrl,
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+} from '@/features';
+import {
+  mockCreateAccount,
+  mockCreateAccountUnexpectedResponseBody,
+  mockInternalServerError,
+} from '@/mocks';
+
+const mockHandlers = [
+  rest.post(getBackendApiUrl('accounts'), mockCreateAccount),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+describe('src/api/server/fetch/account.ts createAccount TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  it('should be able to create an account', async () => {
+    const createdAccount = await createAccount({
+      sub: '99999999999999999999999999999',
+      oidcProvider: 'google',
+    });
+
+    const expected = {
+      id: 1,
+      name: 'すみっこねこ',
+      openIdProviders: [
+        {
+          sub: '99999999999999999999999999999',
+          provider: 'google',
+        },
+      ],
+    };
+
+    expect(createdAccount).toStrictEqual(expected);
+  });
+
+  it('should InvalidResponseBodyError Throw, because unexpected response body', async () => {
+    mockServer.use(
+      rest.post(
+        getBackendApiUrl('accounts'),
+        mockCreateAccountUnexpectedResponseBody
+      )
+    );
+
+    const dto = {
+      sub: '99999999999999999999999999999',
+      oidcProvider: 'google',
+    } as const;
+
+    await expect(createAccount(dto)).rejects.toThrow(InvalidResponseBodyError);
+  });
+
+  it('should UnexpectedFeatureError Throw, because http status is not created', async () => {
+    mockServer.use(
+      rest.post(getBackendApiUrl('accounts'), mockInternalServerError)
+    );
+
+    const dto = {
+      sub: '99999999999999999999999999999',
+      oidcProvider: 'google',
+    } as const;
+
+    await expect(createAccount(dto)).rejects.toThrow(UnexpectedFeatureError);
+  });
+});

--- a/src/api/server/fetch/account.ts
+++ b/src/api/server/fetch/account.ts
@@ -1,0 +1,45 @@
+import type { Account, CreateAccount } from '@/features';
+import {
+  getBackendApiUrl,
+  httpStatusCode,
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  isAccount,
+} from '@/features';
+import type { components } from '@/openapi/schema';
+
+export const createAccount: CreateAccount = async (dto) => {
+  const { sub, oidcProvider } = dto;
+
+  const requestBody: components['schemas']['OpenIdProvider'] = {
+    sub,
+    provider: oidcProvider,
+  };
+
+  const response = await fetch(getBackendApiUrl('accounts'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (response.status !== httpStatusCode.created) {
+    throw new UnexpectedFeatureError(
+      `failed to createAccount. status: ${
+        response.status
+      }, body: ${await response.text()}`
+    );
+  }
+
+  const account = (await response.json()) as Account;
+  if (!isAccount(account)) {
+    throw new InvalidResponseBodyError(
+      `responseBody is not in the expected format. body: ${JSON.stringify(
+        account
+      )}`
+    );
+  }
+
+  return account;
+};

--- a/src/api/server/fetch/account.ts
+++ b/src/api/server/fetch/account.ts
@@ -5,6 +5,7 @@ import {
   InvalidResponseBodyError,
   UnexpectedFeatureError,
   isAccount,
+  createBackendApiBasicAuthCredential,
 } from '@/features';
 import type { components } from '@/openapi/schema';
 
@@ -19,6 +20,7 @@ export const createAccount: CreateAccount = async (dto) => {
   const response = await fetch(getBackendApiUrl('accounts'), {
     method: 'POST',
     headers: {
+      Authorization: `Basic ${createBackendApiBasicAuthCredential()}}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(requestBody),

--- a/src/features/account/account.ts
+++ b/src/features/account/account.ts
@@ -1,0 +1,24 @@
+import type { OidcProvider } from '@/features';
+import type { components } from '@/openapi/schema';
+
+type Sub = components['schemas']['OpenIdProvider']['sub'];
+
+type CreateAccountDto = {
+  sub: Sub;
+  oidcProvider: OidcProvider;
+};
+
+type Account = components['schemas']['Account'] & {
+  readonly openIdProviders: Array<{
+    sub: Sub;
+    provider: OidcProvider;
+  }>;
+};
+
+export type CreateAccount = (dto: CreateAccountDto) => Promise<Account>;
+
+type FindAccountDto = {
+  appToken: string;
+};
+
+export type FindAccount = (dto: FindAccountDto) => Promise<Account | null>;

--- a/src/features/account/account.ts
+++ b/src/features/account/account.ts
@@ -1,4 +1,6 @@
+import { z } from 'zod';
 import type { OidcProvider } from '@/features';
+import { oidcProviderSchema } from '@/features/auth';
 import type { components } from '@/openapi/schema';
 
 type Sub = components['schemas']['OpenIdProvider']['sub'];
@@ -8,11 +10,23 @@ type CreateAccountDto = {
   oidcProvider: OidcProvider;
 };
 
-type Account = components['schemas']['Account'] & {
+export type Account = components['schemas']['Account'] & {
   readonly openIdProviders: Array<{
     sub: Sub;
     provider: OidcProvider;
   }>;
+};
+
+const accountSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  openIdProviders: z.array(oidcProviderSchema),
+});
+
+export const isAccount = (value: unknown): value is Account => {
+  const result = accountSchema.safeParse(value);
+
+  return result.success;
 };
 
 export type CreateAccount = (dto: CreateAccountDto) => Promise<Account>;

--- a/src/features/account/index.ts
+++ b/src/features/account/index.ts
@@ -1,1 +1,2 @@
-export type { CreateAccount, FindAccount } from './account';
+export { isAccount } from './account';
+export type { CreateAccount, FindAccount, Account } from './account';

--- a/src/features/account/index.ts
+++ b/src/features/account/index.ts
@@ -1,0 +1,1 @@
+export type { CreateAccount, FindAccount } from './account';

--- a/src/features/auth/backendApi.ts
+++ b/src/features/auth/backendApi.ts
@@ -1,0 +1,6 @@
+export const createBackendApiBasicAuthCredential = (): string => {
+  const basicAuthUser = process.env.API_BASIC_AUTH_USER ?? '';
+  const basicAuthPassword = process.env.API_BASIC_AUTH_PASSWORD ?? '';
+
+  return btoa(`${basicAuthUser}:${basicAuthPassword}`);
+};

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,2 +1,2 @@
-export { isOidcProvider } from './oidc';
+export { isOidcProvider, oidcProviderSchema } from './oidc';
 export type { OidcProvider } from './oidc';

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,2 +1,3 @@
 export { isOidcProvider, oidcProviderSchema } from './oidc';
 export type { OidcProvider } from './oidc';
+export { createBackendApiBasicAuthCredential } from './backendApi';

--- a/src/features/auth/oidc.ts
+++ b/src/features/auth/oidc.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 // 利用するProviderの種類が増えたら文字列リテラルのユニオン型を使って拡張する
 export type OidcProvider = 'google';
 
@@ -10,3 +12,8 @@ export const isOidcProvider = (value: unknown): value is OidcProvider => {
   // Providerの種類が増えたら https://next-auth.js.org/providers/ を参照
   return value === 'google';
 };
+
+export const oidcProviderSchema = z.object({
+  sub: z.string(),
+  provider: z.literal('google'),
+});

--- a/src/features/errors/InvalidResponseBodyError.ts
+++ b/src/features/errors/InvalidResponseBodyError.ts
@@ -1,0 +1,5 @@
+export class InvalidResponseBodyError extends Error {
+  static {
+    this.prototype.name = 'InvalidResponseBodyError';
+  }
+}

--- a/src/features/errors/UnexpectedFeatureError.ts
+++ b/src/features/errors/UnexpectedFeatureError.ts
@@ -1,0 +1,5 @@
+export class UnexpectedFeatureError extends Error {
+  static {
+    this.prototype.name = 'UnexpectedFeatureError';
+  }
+}

--- a/src/features/errors/index.ts
+++ b/src/features/errors/index.ts
@@ -1,0 +1,2 @@
+export { InvalidResponseBodyError } from './InvalidResponseBodyError';
+export { UnexpectedFeatureError } from './UnexpectedFeatureError';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -7,4 +7,6 @@ export type { GoogleTagManagerId } from './googleTagManagerId';
 export { getNullableGoogleTagManagerId } from './googleTagManagerId';
 export { isOidcProvider } from './auth';
 export type { OidcProvider } from './auth';
-export type { CreateAccount, FindAccount } from './account';
+export { isAccount } from './account';
+export type { Account, CreateAccount, FindAccount } from './account';
+export { InvalidResponseBodyError, UnexpectedFeatureError } from './errors';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,4 +1,4 @@
-export { appUrls, appUrl } from './url';
+export { appUrls, appUrl, getBackendApiUrl } from './url';
 export { GitHubAccountNotFoundError } from './gitHub';
 export type { GitHubAccount, FetchGitHubAccount } from './gitHub';
 export { httpStatusCode } from './httpStatusCode';
@@ -7,3 +7,4 @@ export type { GoogleTagManagerId } from './googleTagManagerId';
 export { getNullableGoogleTagManagerId } from './googleTagManagerId';
 export { isOidcProvider } from './auth';
 export type { OidcProvider } from './auth';
+export type { CreateAccount, FindAccount } from './account';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -5,7 +5,7 @@ export { httpStatusCode } from './httpStatusCode';
 export type { HttpStatusCode } from './httpStatusCode';
 export type { GoogleTagManagerId } from './googleTagManagerId';
 export { getNullableGoogleTagManagerId } from './googleTagManagerId';
-export { isOidcProvider } from './auth';
+export { isOidcProvider, createBackendApiBasicAuthCredential } from './auth';
 export type { OidcProvider } from './auth';
 export { isAccount } from './account';
 export type { Account, CreateAccount, FindAccount } from './account';

--- a/src/features/url/index.ts
+++ b/src/features/url/index.ts
@@ -1,1 +1,1 @@
-export { appUrls, appUrl } from './url';
+export { appUrls, appUrl, getBackendApiUrl } from './url';

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { type paths } from '@/openapi/schema';
 
 const appUrlIdList = ['top', 'gitHubAccountSearch', 'login'] as const;
 
@@ -58,4 +59,40 @@ export const appUrl = (): AppUrl => {
   }
 
   return 'http://localhost:3000';
+};
+
+type BackendApiPaths = {
+  accounts: keyof Pick<paths, '/accounts'>;
+  taskGroups: keyof Pick<paths, '/task-groups'>;
+};
+
+const backendApiPaths: BackendApiPaths = {
+  accounts: '/accounts',
+  taskGroups: '/task-groups',
+};
+
+type BackendApiPath = keyof BackendApiPaths;
+
+type BackendApiUrl = AppUrl;
+
+const isBackendApiUrl = (value: unknown): value is BackendApiUrl => {
+  return isAppUrl(value);
+};
+
+const backendApiUrl = (): BackendApiUrl => {
+  if (isBackendApiUrl(process.env.BACKEND_API_BASE_URL)) {
+    return process.env.BACKEND_API_BASE_URL;
+  }
+
+  return 'http://localhost:5757';
+};
+
+export const getBackendApiUrl = (
+  path: BackendApiPath
+): `${BackendApiUrl}${keyof paths}` => {
+  const apiUrl = backendApiUrl();
+
+  const apiPath: keyof paths = backendApiPaths[path];
+
+  return `${apiUrl}${apiPath}`;
 };

--- a/src/mocks/api/external/index.ts
+++ b/src/mocks/api/external/index.ts
@@ -1,1 +1,2 @@
 export * from './gitHub';
+export * from './timmew';

--- a/src/mocks/api/external/timmew/index.ts
+++ b/src/mocks/api/external/timmew/index.ts
@@ -1,0 +1,2 @@
+export { mockCreateAccount } from './mockCreateAccount';
+export { mockCreateAccountUnexpectedResponseBody } from './mockCreateAccountUnexpectedResponseBody';

--- a/src/mocks/api/external/timmew/mockCreateAccount.ts
+++ b/src/mocks/api/external/timmew/mockCreateAccount.ts
@@ -1,0 +1,25 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockCreateAccount: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.created),
+    ctx.json({
+      id: 1,
+      name: 'すみっこねこ',
+      openIdProviders: [
+        {
+          sub: '99999999999999999999999999999',
+          provider: 'google',
+        },
+      ],
+    })
+  );

--- a/src/mocks/api/external/timmew/mockCreateAccountUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockCreateAccountUnexpectedResponseBody.ts
@@ -1,0 +1,20 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockCreateAccountUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.created),
+    ctx.json({
+      id: 1,
+      name: null,
+      openIdProviders: null,
+    })
+  );


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/73

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/commew/timelogger-web/pull/58 で設計したアカウント作成APIをコールする関数を実装します。

アカウントを取得する関数や実際にこれらの関数を呼び出す処理に関しては別PRで実装します。

# Storybook の URL、 スクリーンショット

今回UI変更ではないのでなし。

# 変更点概要

アカウント作成APIをコールする為の関数を実装しました。

API仕様に関しては下記を参照して下さい。

https://timmew.commew.net/docs/api#/operations/postAccounts

簡単に概要を説明すると `src/features/account/account.ts` に関数のインターフェース（以下はIFと記載）となる型定義 `CreateAccount` を作成し、そのIFを満たすように `src/api/server/fetch/account.ts` 内に `createAccount` を実装しました。

型定義に関しては https://github.com/commew/timelogger-web/pull/71 で生成した型定義ファイルを活かして実装しています。

次回以降のPRも同じような形で実装予定です。

# レビュアーに重点的にチェックして欲しい点

インラインコメントに記載してある点をご確認頂きたいです。

# 補足情報

インラインコメントに記載済。