### PR TITLE
アカウント取得のAPIをコールする関数を実装

### DIFF
--- a/src/api/server/fetch/__tests__/account/findAccount.spec.ts
+++ b/src/api/server/fetch/__tests__/account/findAccount.spec.ts
@@ -1,0 +1,96 @@
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { findAccount } from '@/api/server/fetch/account';
+import {
+  getBackendApiUrl,
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+} from '@/features';
+import {
+  mockFindAccount,
+  mockFindAccountUnexpectedResponseBody,
+  mockAccountUnAuthenticatedError,
+  mockInternalServerError,
+} from '@/mocks';
+
+const mockHandlers = [rest.get(getBackendApiUrl('accounts'), mockFindAccount)];
+
+const mockServer = setupServer(...mockHandlers);
+
+describe('src/api/server/fetch/account.ts findAccount TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  const mockAppToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwiZXhwIjoxNjgzNzMxMzIzLCJqdGkiOiIzNTY3ZGIyNy0zM2RlLTQyMTctOGM5Zi01ODhhYjVkMDdhZGQiLCJpYXQiOjE2ODExMzkzOTZ9.wV-4ftbM7EwPvyzoqWTNKaC1eZko3juJ84Q9C6X_dYs';
+
+  it('should be able to get an account', async () => {
+    const account = await findAccount({
+      appToken: mockAppToken,
+    });
+
+    const expected = {
+      id: 1,
+      name: 'すみっこねこ',
+      openIdProviders: [
+        {
+          sub: '99999999999999999999999999999',
+          provider: 'google',
+        },
+      ],
+    };
+
+    expect(account).toStrictEqual(expected);
+  });
+
+  it('should return null, because the appToken is invalid', async () => {
+    mockServer.use(
+      rest.get(getBackendApiUrl('accounts'), mockAccountUnAuthenticatedError)
+    );
+
+    const dto = {
+      appToken: mockAppToken,
+    } as const;
+
+    const result = await findAccount(dto);
+
+    expect(result).toBeNull();
+  });
+
+  it('should InvalidResponseBodyError Throw, because unexpected response body', async () => {
+    mockServer.use(
+      rest.get(
+        getBackendApiUrl('accounts'),
+        mockFindAccountUnexpectedResponseBody
+      )
+    );
+
+    const dto = {
+      appToken: mockAppToken,
+    } as const;
+
+    await expect(findAccount(dto)).rejects.toThrow(InvalidResponseBodyError);
+  });
+
+  it('should UnexpectedFeatureError Throw, because http status is InternalServerError', async () => {
+    mockServer.use(
+      rest.get(getBackendApiUrl('accounts'), mockInternalServerError)
+    );
+
+    const dto = {
+      appToken: mockAppToken,
+    } as const;
+
+    await expect(findAccount(dto)).rejects.toThrow(UnexpectedFeatureError);
+  });
+});

--- a/src/api/server/fetch/account.ts
+++ b/src/api/server/fetch/account.ts
@@ -1,4 +1,4 @@
-import type { Account, CreateAccount } from '@/features';
+import type { Account, CreateAccount, FindAccount } from '@/features';
 import {
   getBackendApiUrl,
   httpStatusCode,
@@ -29,6 +29,40 @@ export const createAccount: CreateAccount = async (dto) => {
   if (response.status !== httpStatusCode.created) {
     throw new UnexpectedFeatureError(
       `failed to createAccount. status: ${
+        response.status
+      }, body: ${await response.text()}`
+    );
+  }
+
+  const account = (await response.json()) as Account;
+  if (!isAccount(account)) {
+    throw new InvalidResponseBodyError(
+      `responseBody is not in the expected format. body: ${JSON.stringify(
+        account
+      )}`
+    );
+  }
+
+  return account;
+};
+
+export const findAccount: FindAccount = async (dto) => {
+  const { appToken } = dto;
+
+  const response = await fetch(getBackendApiUrl('accounts'), {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${appToken}`,
+    },
+  });
+
+  if (response.status !== httpStatusCode.ok) {
+    if (response.status === httpStatusCode.unauthorized) {
+      return null;
+    }
+
+    throw new UnexpectedFeatureError(
+      `failed to findAccount. status: ${
         response.status
       }, body: ${await response.text()}`
     );

--- a/src/mocks/api/external/timmew/index.ts
+++ b/src/mocks/api/external/timmew/index.ts
@@ -1,2 +1,5 @@
 export { mockCreateAccount } from './mockCreateAccount';
 export { mockCreateAccountUnexpectedResponseBody } from './mockCreateAccountUnexpectedResponseBody';
+export { mockFindAccount } from './mockFindAccount';
+export { mockFindAccountUnexpectedResponseBody } from './mockFindAccountUnexpectedResponseBody';
+export { mockAccountUnAuthenticatedError } from './mockAccountUnAuthenticatedError';

--- a/src/mocks/api/external/timmew/mockAccountUnAuthenticatedError.ts
+++ b/src/mocks/api/external/timmew/mockAccountUnAuthenticatedError.ts
@@ -1,0 +1,19 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockAccountUnAuthenticatedError: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.unauthorized),
+    ctx.json({
+      type: 'UNAUTHENTICATED',
+      title: 'Account is not authenticated.',
+    })
+  );

--- a/src/mocks/api/external/timmew/mockFindAccount.ts
+++ b/src/mocks/api/external/timmew/mockFindAccount.ts
@@ -1,0 +1,25 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockFindAccount: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      id: 1,
+      name: 'すみっこねこ',
+      openIdProviders: [
+        {
+          sub: '99999999999999999999999999999',
+          provider: 'google',
+        },
+      ],
+    })
+  );

--- a/src/mocks/api/external/timmew/mockFindAccountUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockFindAccountUnexpectedResponseBody.ts
@@ -1,0 +1,20 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockFindAccountUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      id: 1,
+      name: null,
+      openIdProviders: null,
+    })
+  );


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/73

# この PR で対応する範囲 / この PR で対応しない範囲

[アカウント取得API](https://timmew.commew.net/docs/api#/operations/getAccounts) をコールする為の関数を実装する。

実際に関数を呼び出す部分に関しては別PRで実装してここではテストコードで動作担保する。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし。

# 変更点概要

PRタイトルの通り [アカウント取得API](https://timmew.commew.net/docs/api#/operations/getAccounts) をコールする為の関数を実装しました。

変更点が分かりにくて申し訳ないのですが実は https://github.com/commew/timelogger-web/pull/75 の時点で本PRで実装したアカウント取得用の関数IFを実装していました。

今回はそのIFを利用して `findAccount` 関数を実装しています。

# レビュアーに重点的にチェックして欲しい点

特筆すべき点は特にありませんが、テストケースで追加したほうが良いテストケースがあればご提案頂きたいのと、何か気がついた事があれば何でもコメント下さい！

# 補足情報

特になし