### PR TITLE
サイドバーにTaskMeasurementCategoryButtonを組み込んだ

### DIFF
--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -82,7 +82,10 @@ export const SideBar: FC = () => {
     <Navbar height={800} p="md" className={classes.navbar}>
       <Navbar.Section grow>
         {mockGroups.map((group) => (
-          <Group key={group.id}>
+          <Group
+            key={group.id}
+            sx={{ rowGap: theme.spacing.xs, paddingBottom: theme.spacing.xs }}
+          >
             <UnstyledButton
               onClick={() => {
                 setOpened((prevOpened) => ({
@@ -108,16 +111,14 @@ export const SideBar: FC = () => {
                 </Box>
               </Group>
             </UnstyledButton>
-            <Collapse in={opened[group.id]} pl={'1.25rem'}>
-              <Group>
-                {group.categories.map((category) => {
-                  return (
-                    <TaskMeasurementCategoryButton
-                      key={category.id}
-                      name={category.name}
-                    />
-                  );
-                })}
+            <Collapse in={opened[group.id]} pl={'1.25rem'} w={'100%'}>
+              <Group spacing={0}>
+                {group.categories.map((category) => (
+                  <TaskMeasurementCategoryButton
+                    key={category.id}
+                    name={category.name}
+                  />
+                ))}
               </Group>
             </Collapse>
           </Group>

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -51,75 +51,25 @@ type CategoryGroup = Readonly<{
 const mockGroups: CategoryGroup[] = [
   {
     id: 1,
-    name: 'グループ名1',
+    name: '仕事',
     categories: [
-      {
-        id: 1,
-        name: 'カテゴリ名1',
-      },
-      {
-        id: 2,
-        name: 'カテゴリ名2',
-      },
-      {
-        id: 3,
-        name: 'カテゴリ名3',
-      },
+      { id: 1, name: '会議' },
+      { id: 2, name: '資料作成' },
     ],
   },
-  {
-    id: 2,
-    name: 'グループ名2',
-    categories: [
-      {
-        id: 4,
-        name: 'カテゴリ名4',
-      },
-      {
-        id: 5,
-        name: 'カテゴリ名5',
-      },
-      {
-        id: 6,
-        name: 'カテゴリ名6',
-      },
-    ],
-  },
+  { id: 2, name: '学習', categories: [{ id: 3, name: 'TOEIC' }] },
   {
     id: 3,
-    name: 'グループ名3',
+    name: '趣味',
     categories: [
-      {
-        id: 7,
-        name: 'カテゴリ名7',
-      },
-      {
-        id: 8,
-        name: 'カテゴリ名8',
-      },
-      {
-        id: 9,
-        name: 'カテゴリ名9',
-      },
+      { id: 4, name: '散歩' },
+      { id: 5, name: '読書' },
     ],
   },
   {
     id: 4,
-    name: 'グループ名4',
-    categories: [
-      {
-        id: 10,
-        name: 'カテゴリ名10',
-      },
-      {
-        id: 11,
-        name: 'カテゴリ名11',
-      },
-      {
-        id: 12,
-        name: 'カテゴリ名12',
-      },
-    ],
+    name: 'グループ未分類',
+    categories: [{ id: 6, name: '移動・外出' }],
   },
 ];
 

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -7,9 +7,9 @@ import {
   Navbar,
   UnstyledButton,
   createStyles,
-  NavLink,
 } from '@mantine/core';
-import { IconChevronUp, IconChevronDown, IconHome } from '@tabler/icons-react';
+import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
+import { TaskMeasurementCategoryButton } from '../TaskMeasurementCategoryButton';
 
 const useStyles = createStyles((theme) => ({
   button: {
@@ -110,52 +110,20 @@ export const SideBar: FC = () => {
             </UnstyledButton>
             <Collapse in={opened[group.id]} pl={'1.25rem'}>
               <Group>
-                <NavLink
-                  icon={
-                    <IconHome
-                      size="1rem"
-                      stroke={1.5}
-                      color={theme.colors.blue[6]}
+                {group.categories.map((category) => {
+                  return (
+                    <TaskMeasurementCategoryButton
+                      key={category.id}
+                      name={category.name}
                     />
-                  }
-                  label="カテゴリ名"
-                ></NavLink>
-                <NavLink
-                  icon={
-                    <IconHome
-                      size="1rem"
-                      stroke={1.5}
-                      color={theme.colors.blue[6]}
-                    />
-                  }
-                  label="カテゴリ名カテゴリ名カテゴリ名カテゴリ名カテゴリ名カテゴリ名"
-                ></NavLink>
-                <NavLink
-                  icon={
-                    <IconHome
-                      size="1rem"
-                      stroke={1.5}
-                      color={theme.colors.blue[6]}
-                    />
-                  }
-                  label="カテゴリ名"
-                ></NavLink>
+                  );
+                })}
               </Group>
             </Collapse>
           </Group>
         ))}
-        <NavLink
-          icon={
-            <IconHome size="1rem" stroke={1.5} color={theme.colors.blue[6]} />
-          }
-          label="カテゴリ名"
-        ></NavLink>
-        <NavLink
-          icon={
-            <IconHome size="1rem" stroke={1.5} color={theme.colors.blue[6]} />
-          }
-          label="カテゴリ名"
-        ></NavLink>
+        <TaskMeasurementCategoryButton name="カテゴリ名" />
+        <TaskMeasurementCategoryButton name="カテゴリ名" />
       </Navbar.Section>
     </Navbar>
   );


### PR DESCRIPTION
# issueURL

#47 

# この PR で対応する範囲 / この PR で対応しない範囲
- 以前 #66 で実装したコンポーネントをSideBarコンポーネントに組み込む対応を行う
- APIへのリクエスト機能は本プルリクでは対応しない

# Storybook の URL、 スクリーンショット
[Storybook](https://63d52217f1430a5ad69846cd-itintxbsfz.chromatic.com/?path=/story/components-sidebar--default)
![May-28-2023 17-15-02](https://github.com/commew/timelogger-web/assets/9443634/5d2acff0-8561-4cc4-a51f-f3b8453f4c07)

# 変更点概要

SideBarコンポーネントに直接記述されていたタスク計測開始ボタンを#66 で実装したコンポーネントに差し替えました。
差し替えにあたり、若干スタイルを調整しています。

# レビュアーに重点的にチェックして欲しい点

ソース内コメントに記述しています。

# 補足情報
とくになし