### PR TITLE
#81 停止中のタスクアイテムコンポーネントを実装

### DIFF
--- a/src/components/StoppedTaskItem/StoppedTaskItem.stories.tsx
+++ b/src/components/StoppedTaskItem/StoppedTaskItem.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStoryObj } from '@storybook/react';
+import { StoppedTaskItem } from './StoppedTaskItem';
+
+const story = {
+  component: StoppedTaskItem,
+};
+
+export default story;
+
+type Story = ComponentStoryObj<typeof StoppedTaskItem>;
+
+export const Default: Story = {
+  args: {
+    categoryName: 'カテゴリ名',
+    categoryGroupName: 'グループ名',
+    isMeasuring: true,
+  },
+};

--- a/src/components/StoppedTaskItem/StoppedTaskItem.stories.tsx
+++ b/src/components/StoppedTaskItem/StoppedTaskItem.stories.tsx
@@ -13,6 +13,6 @@ export const Default: Story = {
   args: {
     categoryName: 'カテゴリ名',
     categoryGroupName: 'グループ名',
-    isMeasuring: true,
+    isMeasuring: false,
   },
 };

--- a/src/components/StoppedTaskItem/StoppedTaskItem.tsx
+++ b/src/components/StoppedTaskItem/StoppedTaskItem.tsx
@@ -1,0 +1,125 @@
+import type { FC } from 'react';
+import { Box, Button, createStyles, Flex, Group, Text } from '@mantine/core';
+import {
+  IconPlayerPause,
+  IconHome,
+  IconSquare,
+  IconPlayerPlay,
+} from '@tabler/icons-react';
+
+const useStyles = createStyles((theme) => ({
+  button: {
+    width: '80px',
+    height: '34px',
+    padding: '7px 10px',
+  },
+  task_item: {
+    borderLeft: '5px solid #79D08D',
+    padding: '0.5rem 1rem',
+    maxWidth: '800px',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    columnGap: theme.spacing.xl,
+  },
+}));
+
+type Props = {
+  categoryName: string;
+  categoryGroupName: string;
+  isMeasuring: boolean;
+};
+
+export const StoppedTaskItem: FC<Props> = ({
+  categoryName,
+  categoryGroupName,
+  isMeasuring,
+}) => {
+  const { classes, theme } = useStyles();
+
+  return (
+    <Flex className={classes.task_item}>
+      <Flex
+        align="center"
+        justify="space-between"
+        columnGap="xl"
+        style={{ maxWidth: '400px', width: '100%' }}
+      >
+        <Flex align="center" columnGap="1rem">
+          <IconHome size="2.5rem" stroke={1.5} color="#79D08D" />
+          <Flex direction="column">
+            <Text color="dark.6" fz="sm">
+              {categoryGroupName}
+            </Text>
+            <Text color="dark.6" fz="xl">
+              {categoryName}
+            </Text>
+          </Flex>
+        </Flex>
+
+        <Box>
+          <Text fz="sm">計測時間</Text>
+          <Text color="dark.6" fz={theme.headings.sizes.h1.fontSize} fw={700}>
+            00:00:10 {/* TODO: ここは動的に値を変更できるようにする */}
+          </Text>
+        </Box>
+      </Flex>
+
+      <Group style={{ alignSelf: 'flex-end' }}>
+        {isMeasuring ? (
+          <Button
+            leftIcon={
+              <IconPlayerPause
+                size="1.25rem"
+                color={theme.colors.gray[0]}
+                stroke={2.75}
+              />
+            }
+            color="indigo.6"
+            className={classes.button}
+            styles={{ leftIcon: { marginRight: '0.5rem' } }}
+            aria-label="STOP"
+          >
+            <Text color="gray.0" fz="xs" fw={700}>
+              停止
+            </Text>
+          </Button>
+        ) : (
+          <Button
+            leftIcon={
+              <IconPlayerPlay
+                size="1.25rem"
+                color={theme.colors.gray[0]}
+                stroke={2.75}
+              />
+            }
+            color="red.6"
+            className={classes.button}
+            styles={{ leftIcon: { marginRight: '0.5rem' } }}
+            aria-label="START"
+          >
+            <Text color="gray.0" fz="xs" fw={700}>
+              開始
+            </Text>
+          </Button>
+        )}
+        <Button
+          leftIcon={
+            <IconSquare
+              size="1rem"
+              color={theme.colors.dark[6]}
+              stroke={2.75}
+            />
+          }
+          color="gray.4"
+          className={classes.button}
+          styles={{ leftIcon: { marginRight: '0.5rem' } }}
+          aria-label="COMPLETE"
+        >
+          <Text color="dark.6" fw={700} fz="xs">
+            終了
+          </Text>
+        </Button>
+      </Group>
+    </Flex>
+  );
+};

--- a/src/components/StoppedTaskItem/__tests__/StoppedTaskItem.spec.tsx
+++ b/src/components/StoppedTaskItem/__tests__/StoppedTaskItem.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { StoppedTaskItem } from '@/components';
+
+describe('src/components/StoppedTaskItem/StoppedTaskItem.tsx TestCases', () => {
+  it('should display the name', () => {
+    const expected = 'カテゴリ名';
+
+    render(
+      <StoppedTaskItem
+        categoryName="カテゴリ名"
+        categoryGroupName="グループ名"
+        isMeasuring={true}
+      />
+    );
+
+    expect(screen.getByText(expected)).toBeTruthy();
+  });
+  // TODO: テストケースをちゃんと考える
+});

--- a/src/components/StoppedTaskItem/index.tsx
+++ b/src/components/StoppedTaskItem/index.tsx
@@ -1,0 +1,1 @@
+export { StoppedTaskItem } from './StoppedTaskItem';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export { HeaderNavigation } from './HeaderNavigation';
 export { SideBar } from './SideBar';
 export { TaskMeasurementCategoryButton } from './TaskMeasurementCategoryButton';
 export { MeasuringTaskItem } from './MeasuringTaskItem';
+export { StoppedTaskItem } from './StoppedTaskItem';


### PR DESCRIPTION
# issueURL

#81

# この PR で対応する範囲 / この PR で対応しない範囲

- この PR では Component の作成のみで API への通信ロジックは別 PR で対応します。

# Storybook の URL、 スクリーンショット

[Storybook](https://63d52217f1430a5ad69846cd-dzoxljhhkv.chromatic.com/?path=/story/components-stoppedtaskitem--default)

# 変更点概要

とくになし

# レビュアーに重点的にチェックして欲しい点

補足情報に記載の通り、既存のコンポーネントのほぼコピーです。
したがって、そこまでレビューに時間をかけていただく必要はない認識です。

# 補足情報

[こちら](https://github.com/commew/timelogger-web/pull/82#discussion_r1213184202)のやり取りから、一旦計測中のタスクと停止中のタスクのコンポーネントを分けて実装し、後で`TaskItem`などの名前で1つのコンポーネントに統合する予定です。

したがって、本PRで実装したコンポーネントは、 #82 と配色が異なるだけで現状ほぼ同等のコンポーネントになっています。
※ API ロジック実装時に処理内容やPropsなどの差異が出てくる想定です。
その差異を吸収できるなら統合、できないならそのまま別々のコンポーネントにするのもありという認識です。
