### PR TITLE
タスク計測を開始するためのリクエスト機能を実装した

### DIFF
--- a/src/api/client/fetch/__tests__/task/createTask.spec.ts
+++ b/src/api/client/fetch/__tests__/task/createTask.spec.ts
@@ -30,9 +30,13 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
     mockServer.close();
   });
 
+  const mockAppToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwiZXhwIjoxNjgzNzMxMzIzLCJqdGkiOiIzNTY3ZGIyNy0zM2RlLTQyMTctOGM5Zi01ODhhYjVkMDdhZGQiLCJpYXQiOjE2ODExMzkzOTZ9.wV-4ftbM7EwPvyzoqWTNKaC1eZko3juJ84Q9C6X_dYs';
+
   it('should be able to create a task', async () => {
     const createdTask = await createTask({
       taskCategoryId: 1,
+      appToken: mockAppToken,
     });
 
     const expected = {
@@ -52,6 +56,7 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
 
     const dto = {
       taskCategoryId: 1,
+      appToken: mockAppToken,
     } as const;
 
     await expect(createTask(dto)).rejects.toThrow(InvalidResponseBodyError);
@@ -64,6 +69,7 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
 
     const dto = {
       taskCategoryId: 1,
+      appToken: mockAppToken,
     } as const;
 
     await expect(createTask(dto)).rejects.toThrow(UnexpectedFeatureError);

--- a/src/api/client/fetch/__tests__/task/createTask.spec.ts
+++ b/src/api/client/fetch/__tests__/task/createTask.spec.ts
@@ -1,0 +1,71 @@
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { createTask } from '@/api/client/fetch/task';
+import {
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  getBackendApiUrl,
+} from '@/features';
+import {
+  mockCreateTask,
+  mockCreateTaskUnexpectedResponseBody,
+  mockInternalServerError,
+} from '@/mocks';
+
+const mockHandlers = [rest.post(getBackendApiUrl('tasks'), mockCreateTask)];
+
+const mockServer = setupServer(...mockHandlers);
+
+describe('src/api/client/fetch/task.ts createTask TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  it('should be able to create a task', async () => {
+    const createdTask = await createTask({
+      taskCategoryId: 1,
+    });
+
+    const expected = {
+      id: 1,
+      status: 'recording',
+      startAt: '2019-08-24T14:15:22Z',
+      taskCategoryId: 1,
+    };
+
+    expect(createdTask).toStrictEqual(expected);
+  });
+
+  it('should InvalidResponseBodyError Throw, because unexpected response body', async () => {
+    mockServer.use(
+      rest.post(getBackendApiUrl('tasks'), mockCreateTaskUnexpectedResponseBody)
+    );
+
+    const dto = {
+      taskCategoryId: 1,
+    } as const;
+
+    await expect(createTask(dto)).rejects.toThrow(InvalidResponseBodyError);
+  });
+
+  it('should UnexpectedFeatureError Throw, because http status is not created', async () => {
+    mockServer.use(
+      rest.post(getBackendApiUrl('tasks'), mockInternalServerError)
+    );
+
+    const dto = {
+      taskCategoryId: 1,
+    } as const;
+
+    await expect(createTask(dto)).rejects.toThrow(UnexpectedFeatureError);
+  });
+});

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -9,7 +9,7 @@ import {
 import type { components } from '@/openapi/schema';
 
 export const createTask: CreateTask = async (dto) => {
-  const { taskCategoryId } = dto;
+  const { taskCategoryId, appToken } = dto;
 
   const requestBody: components['schemas']['Task'] = {
     taskCategoryId,
@@ -18,7 +18,7 @@ export const createTask: CreateTask = async (dto) => {
   const response = await fetch(getBackendApiUrl('tasks'), {
     method: 'POST',
     headers: {
-      Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`,
+      Authorization: `Bearer ${appToken}`,
       'Content-Type': 'application/json',
       Prefer: 'code=201, example=ExampleSuccess',
     },

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -1,0 +1,45 @@
+import type { Task, CreateTask } from '@/features';
+import {
+  getBackendApiUrl,
+  httpStatusCode,
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  isTask,
+} from '@/features';
+import type { components } from '@/openapi/schema';
+
+export const createTask: CreateTask = async (dto) => {
+  const { taskCategoryId } = dto;
+
+  const requestBody: components['schemas']['Task'] = {
+    taskCategoryId
+  };
+
+  const response = await fetch(getBackendApiUrl('tasks'), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`,
+      'Content-Type': 'application/json',
+      Prefer: 'code=201, example=ExampleSuccess',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (response.status !== httpStatusCode.created) {
+    throw new UnexpectedFeatureError(
+      `failed to createTask. status: ${response.status
+      }, body: ${await response.text()}`
+    );
+  }
+
+  const task = (await response.json()) as Task;
+  if (!isTask(task)) {
+    throw new InvalidResponseBodyError(
+      `responseBody is not in the expected format. body: ${JSON.stringify(
+        task
+      )}`
+    );
+  }
+
+  return task;
+};

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -12,7 +12,7 @@ export const createTask: CreateTask = async (dto) => {
   const { taskCategoryId } = dto;
 
   const requestBody: components['schemas']['Task'] = {
-    taskCategoryId
+    taskCategoryId,
   };
 
   const response = await fetch(getBackendApiUrl('tasks'), {
@@ -27,7 +27,8 @@ export const createTask: CreateTask = async (dto) => {
 
   if (response.status !== httpStatusCode.created) {
     throw new UnexpectedFeatureError(
-      `failed to createTask. status: ${response.status
+      `failed to createTask. status: ${
+        response.status
       }, body: ${await response.text()}`
     );
   }

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -9,4 +9,6 @@ export { isOidcProvider, createBackendApiBasicAuthCredential } from './auth';
 export type { OidcProvider } from './auth';
 export { isAccount } from './account';
 export type { Account, CreateAccount, FindAccount } from './account';
+export { isTask } from './task';
+export type { Task, CreateTask } from './task';
 export { InvalidResponseBodyError, UnexpectedFeatureError } from './errors';

--- a/src/features/task/index.ts
+++ b/src/features/task/index.ts
@@ -1,0 +1,2 @@
+export { isTask } from './task';
+export type { Task, CreateTask } from './task';

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -3,6 +3,7 @@ import type { components } from '@/openapi/schema';
 
 type CreateTaskDto = {
   taskCategoryId: number;
+  appToken: string;
 };
 
 export type Task = components['schemas']['Task'];

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import type { components } from '@/openapi/schema';
+
+type CreateTaskDto = {
+  taskCategoryId: number;
+};
+
+export type Task = components['schemas']['Task'];
+
+const taskSchema = z.object({
+  id: z.optional(z.number()),
+  status: z.optional(
+    z.union([
+      z.literal('pending'),
+      z.literal('completed'),
+      z.literal('recording'),
+    ])
+  ),
+  startAt: z.optional(z.string()),
+  endAt: z.optional(z.string()),
+  duration: z.optional(z.number()),
+  taskCategoryId: z.number(),
+});
+
+export const isTask = (value: unknown): value is Task => {
+  const result = taskSchema.safeParse(value);
+
+  return result.success;
+};
+
+export type CreateTask = (dto: CreateTaskDto) => Promise<Task>;

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -70,7 +70,7 @@ type BackendApiPaths = {
 const backendApiPaths: BackendApiPaths = {
   accounts: '/accounts',
   taskGroups: '/task-groups',
-  tasks: '/tasks'
+  tasks: '/tasks',
 };
 
 type BackendApiPath = keyof BackendApiPaths;

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -64,11 +64,13 @@ export const appUrl = (): AppUrl => {
 type BackendApiPaths = {
   accounts: keyof Pick<paths, '/accounts'>;
   taskGroups: keyof Pick<paths, '/task-groups'>;
+  tasks: keyof Pick<paths, '/tasks'>;
 };
 
 const backendApiPaths: BackendApiPaths = {
   accounts: '/accounts',
   taskGroups: '/task-groups',
+  tasks: '/tasks'
 };
 
 type BackendApiPath = keyof BackendApiPaths;

--- a/src/mocks/api/external/timmew/index.ts
+++ b/src/mocks/api/external/timmew/index.ts
@@ -2,4 +2,6 @@ export { mockCreateAccount } from './mockCreateAccount';
 export { mockCreateAccountUnexpectedResponseBody } from './mockCreateAccountUnexpectedResponseBody';
 export { mockFindAccount } from './mockFindAccount';
 export { mockFindAccountUnexpectedResponseBody } from './mockFindAccountUnexpectedResponseBody';
+export { mockCreateTask } from './mockCreateTask';
+export { mockCreateTaskUnexpectedResponseBody } from './mockCreateTaskUnexpectedResponseBody';
 export { mockAccountUnAuthenticatedError } from './mockAccountUnAuthenticatedError';

--- a/src/mocks/api/external/timmew/mockCreateTask.ts
+++ b/src/mocks/api/external/timmew/mockCreateTask.ts
@@ -1,0 +1,21 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockCreateTask: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.created),
+    ctx.json({
+      id: 1,
+      status: 'recording',
+      startAt: '2019-08-24T14:15:22Z',
+      taskCategoryId: 1,
+    })
+  );

--- a/src/mocks/api/external/timmew/mockCreateTaskUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockCreateTaskUnexpectedResponseBody.ts
@@ -1,0 +1,18 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockCreateTaskUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.created),
+    ctx.json({
+      taskCategoryId: null,
+    })
+  );


### PR DESCRIPTION
# issueURL

#47 

# この PR で対応する範囲 / この PR で対応しない範囲

- この PR では タスク計測開始用の API リクエスト機能を実装します。
- コンポーネントへの実装は別 PR で行います。

# Storybook の URL、 スクリーンショット

特になし（ロジックの実装のみなので）

# 変更点概要

主にタスク計測開始をリクエストするためのビジネスロジックを実装しました。

# レビュアーに重点的にチェックして欲しい点

ビジネスロジックの実装が初めてなので、下記を重点的に見ていただけると大変うれしいです🙏
- コードの配置は適切か
- テストケースに過不足はないか

その他実装の意図などをコード内にコメントとして記述します。
そちらも併せてご確認いただけると嬉しいです。
どうぞよろしくお願いいたします。

# 補足情報

実装にあたって、keita さんが事前に実装してくださったアカウントのビジネスロジックに関するコードを大いに参考にさせていただきました。
具体的には` features/account/ ` および ` api/server/fetch/account.ts ` の構造です。


