### PR TITLE
タスクの記録を停止する機能を実装する

### DIFF
--- a/src/api/client/fetch/__tests__/task/stopTask.spec.ts
+++ b/src/api/client/fetch/__tests__/task/stopTask.spec.ts
@@ -5,7 +5,7 @@ import { stopTask } from '@/api/client/fetch/task';
 import {
   InvalidResponseBodyError,
   UnexpectedFeatureError,
-  getBackendApiUrl,
+  getDynamicBackendApiUrl,
 } from '@/features';
 import {
   mockStopTask,
@@ -14,10 +14,7 @@ import {
 } from '@/mocks';
 
 const mockHandlers = [
-  rest.patch(
-    getBackendApiUrl('tasks/{taskId}/stop').replace('{taskId}', '1'),
-    mockStopTask
-  ),
+  rest.patch(getDynamicBackendApiUrl('stopTask', '1'), mockStopTask),
 ];
 
 const mockServer = setupServer(...mockHandlers);
@@ -59,7 +56,7 @@ describe('src/api/client/fetch/task.ts stopTask TestCases', () => {
   it('should InvalidResponseBodyError Throw, because unexpected response body', async () => {
     mockServer.use(
       rest.patch(
-        getBackendApiUrl('tasks/{taskId}/stop').replace('{taskId}', '1'),
+        getDynamicBackendApiUrl('stopTask', '1'),
         mockStopTaskUnexpectedResponseBody
       )
     );
@@ -75,7 +72,7 @@ describe('src/api/client/fetch/task.ts stopTask TestCases', () => {
   it('should UnexpectedFeatureError Throw, because http status is not ok', async () => {
     mockServer.use(
       rest.patch(
-        getBackendApiUrl('tasks/{taskId}/stop').replace('{taskId}', '1'),
+        getDynamicBackendApiUrl('stopTask', '1'),
         mockInternalServerError
       )
     );

--- a/src/api/client/fetch/__tests__/task/stopTask.spec.ts
+++ b/src/api/client/fetch/__tests__/task/stopTask.spec.ts
@@ -1,0 +1,90 @@
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { stopTask } from '@/api/client/fetch/task';
+import {
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  getBackendApiUrl,
+} from '@/features';
+import {
+  mockStopTask,
+  mockStopTaskUnexpectedResponseBody,
+  mockInternalServerError,
+} from '@/mocks';
+
+const mockHandlers = [
+  rest.patch(
+    getBackendApiUrl('tasks/{taskId}/stop').replace('{taskId}', '1'),
+    mockStopTask
+  ),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+describe('src/api/client/fetch/task.ts stopTask TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  const mockAppToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwiZXhwIjoxNjgzNzMxMzIzLCJqdGkiOiIzNTY3ZGIyNy0zM2RlLTQyMTctOGM5Zi01ODhhYjVkMDdhZGQiLCJpYXQiOjE2ODExMzkzOTZ9.wV-4ftbM7EwPvyzoqWTNKaC1eZko3juJ84Q9C6X_dYs';
+
+  it('should be able to stop a task', async () => {
+    const createdTask = await stopTask({
+      taskId: 1,
+      appToken: mockAppToken,
+    });
+
+    const expected = {
+      id: 1,
+      status: 'pending',
+      startAt: '2019-08-24T14:15:22Z',
+      endAt: '2019-08-24T16:15:22Z',
+      duration: 7200,
+      taskCategoryId: 1,
+    };
+
+    expect(createdTask).toStrictEqual(expected);
+  });
+
+  it('should InvalidResponseBodyError Throw, because unexpected response body', async () => {
+    mockServer.use(
+      rest.patch(
+        getBackendApiUrl('tasks/{taskId}/stop').replace('{taskId}', '1'),
+        mockStopTaskUnexpectedResponseBody
+      )
+    );
+
+    const dto = {
+      taskId: 1,
+      appToken: mockAppToken,
+    } as const;
+
+    await expect(stopTask(dto)).rejects.toThrow(InvalidResponseBodyError);
+  });
+
+  it('should UnexpectedFeatureError Throw, because http status is not ok', async () => {
+    mockServer.use(
+      rest.patch(
+        getBackendApiUrl('tasks/{taskId}/stop').replace('{taskId}', '1'),
+        mockInternalServerError
+      )
+    );
+
+    const dto = {
+      taskId: 1,
+      appToken: mockAppToken,
+    } as const;
+
+    await expect(stopTask(dto)).rejects.toThrow(UnexpectedFeatureError);
+  });
+});

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -1,4 +1,4 @@
-import type { Task, CreateTask } from '@/features';
+import type { Task, CreateTask, StopTask } from '@/features';
 import {
   getBackendApiUrl,
   httpStatusCode,
@@ -26,6 +26,40 @@ export const createTask: CreateTask = async (dto) => {
   });
 
   if (response.status !== httpStatusCode.created) {
+    throw new UnexpectedFeatureError(
+      `failed to createTask. status: ${
+        response.status
+      }, body: ${await response.text()}`
+    );
+  }
+
+  const task = (await response.json()) as Task;
+  if (!isTask(task)) {
+    throw new InvalidResponseBodyError(
+      `responseBody is not in the expected format. body: ${JSON.stringify(
+        task
+      )}`
+    );
+  }
+
+  return task;
+};
+
+export const stopTask: StopTask = async (dto) => {
+  const { taskId, appToken } = dto;
+
+  const response = await fetch(
+    getBackendApiUrl('tasks/{taskId}/stop').replace('{taskId}', `${taskId}`),
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${appToken}`,
+        Prefer: 'code=200, example=ExampleSuccess',
+      },
+    }
+  );
+
+  if (response.status !== httpStatusCode.ok) {
     throw new UnexpectedFeatureError(
       `failed to createTask. status: ${
         response.status

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -5,6 +5,7 @@ import {
   InvalidResponseBodyError,
   UnexpectedFeatureError,
   isTask,
+  getDynamicBackendApiUrl,
 } from '@/features';
 import type { components } from '@/openapi/schema';
 
@@ -49,7 +50,7 @@ export const stopTask: StopTask = async (dto) => {
   const { taskId, appToken } = dto;
 
   const response = await fetch(
-    getBackendApiUrl('tasks/{taskId}/stop').replace('{taskId}', `${taskId}`),
+    getDynamicBackendApiUrl('stopTask', `${taskId}`),
     {
       method: 'PATCH',
       headers: {

--- a/src/features/errors/ExhaustiveError.ts
+++ b/src/features/errors/ExhaustiveError.ts
@@ -1,0 +1,10 @@
+export class ExhaustiveError extends Error {
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  constructor(value: never, message = `Unsupported type: ${value}`) {
+    super(message);
+  }
+
+  static {
+    this.prototype.name = 'ExhaustiveError';
+  }
+}

--- a/src/features/errors/index.ts
+++ b/src/features/errors/index.ts
@@ -1,2 +1,3 @@
 export { InvalidResponseBodyError } from './InvalidResponseBodyError';
 export { UnexpectedFeatureError } from './UnexpectedFeatureError';
+export { ExhaustiveError } from './ExhaustiveError';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,4 +1,9 @@
-export { appUrls, appUrl, getBackendApiUrl } from './url';
+export {
+  appUrls,
+  appUrl,
+  getBackendApiUrl,
+  getDynamicBackendApiUrl,
+} from './url';
 export { GitHubAccountNotFoundError } from './gitHub';
 export type { GitHubAccount, FetchGitHubAccount } from './gitHub';
 export { httpStatusCode } from './httpStatusCode';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -10,5 +10,5 @@ export type { OidcProvider } from './auth';
 export { isAccount } from './account';
 export type { Account, CreateAccount, FindAccount } from './account';
 export { isTask } from './task';
-export type { Task, CreateTask } from './task';
+export type { Task, CreateTask, StopTask } from './task';
 export { InvalidResponseBodyError, UnexpectedFeatureError } from './errors';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -16,4 +16,8 @@ export { isAccount } from './account';
 export type { Account, CreateAccount, FindAccount } from './account';
 export { isTask } from './task';
 export type { Task, CreateTask, StopTask } from './task';
-export { InvalidResponseBodyError, UnexpectedFeatureError } from './errors';
+export {
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  ExhaustiveError,
+} from './errors';

--- a/src/features/task/index.ts
+++ b/src/features/task/index.ts
@@ -1,2 +1,2 @@
 export { isTask } from './task';
-export type { Task, CreateTask } from './task';
+export type { Task, CreateTask, StopTask } from './task';

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -6,6 +6,11 @@ type CreateTaskDto = {
   appToken: string;
 };
 
+type StopTaskDto = {
+  taskId: number;
+  appToken: string;
+};
+
 export type Task = components['schemas']['Task'];
 
 const taskSchema = z.object({
@@ -30,3 +35,4 @@ export const isTask = (value: unknown): value is Task => {
 };
 
 export type CreateTask = (dto: CreateTaskDto) => Promise<Task>;
+export type StopTask = (dto: StopTaskDto) => Promise<Task>;

--- a/src/features/url/index.ts
+++ b/src/features/url/index.ts
@@ -1,1 +1,6 @@
-export { appUrls, appUrl, getBackendApiUrl } from './url';
+export {
+  appUrls,
+  appUrl,
+  getBackendApiUrl,
+  getDynamicBackendApiUrl,
+} from './url';

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -65,14 +65,12 @@ type BackendApiPaths = {
   accounts: keyof Pick<paths, '/accounts'>;
   taskGroups: keyof Pick<paths, '/task-groups'>;
   tasks: keyof Pick<paths, '/tasks'>;
-  'tasks/{taskId}/stop': keyof Pick<paths, '/tasks/{taskId}/stop'>;
 };
 
 const backendApiPaths: BackendApiPaths = {
   accounts: '/accounts',
   taskGroups: '/task-groups',
   tasks: '/tasks',
-  'tasks/{taskId}/stop': '/tasks/{taskId}/stop',
 };
 
 type BackendApiPath = keyof BackendApiPaths;
@@ -99,4 +97,38 @@ export const getBackendApiUrl = (
   const apiPath: keyof paths = backendApiPaths[path];
 
   return `${apiUrl}${apiPath}`;
+};
+
+type DynamicBackendApiPaths = {
+  stopTask: (
+    path: keyof Pick<paths, '/tasks/{taskId}/stop'>,
+    param: string
+  ) => string;
+};
+
+type DynamicBackendApiPath = keyof DynamicBackendApiPaths;
+
+const dynamicBackendApiPaths: DynamicBackendApiPaths = {
+  stopTask: (path, param) => path.replace('{taskId}', `${param}`),
+};
+
+export const getDynamicBackendApiUrl = (
+  path: DynamicBackendApiPath,
+  param: string
+): string => {
+  const apiUrl = backendApiUrl();
+
+  switch (path) {
+    case 'stopTask': {
+      const apiPath = dynamicBackendApiPaths[path](
+        '/tasks/{taskId}/stop',
+        param
+      );
+
+      return `${apiUrl}${apiPath}`;
+    }
+
+    default:
+      throw new Error();
+  }
 };

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -65,12 +65,14 @@ type BackendApiPaths = {
   accounts: keyof Pick<paths, '/accounts'>;
   taskGroups: keyof Pick<paths, '/task-groups'>;
   tasks: keyof Pick<paths, '/tasks'>;
+  'tasks/{taskId}/stop': keyof Pick<paths, '/tasks/{taskId}/stop'>;
 };
 
 const backendApiPaths: BackendApiPaths = {
   accounts: '/accounts',
   taskGroups: '/task-groups',
   tasks: '/tasks',
+  'tasks/{taskId}/stop': '/tasks/{taskId}/stop',
 };
 
 type BackendApiPath = keyof BackendApiPaths;

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { type paths } from '@/openapi/schema';
+import { ExhaustiveError } from '../errors';
 
 const appUrlIdList = ['top', 'gitHubAccountSearch', 'login'] as const;
 
@@ -129,6 +130,6 @@ export const getDynamicBackendApiUrl = (
     }
 
     default:
-      throw new Error();
+      throw new ExhaustiveError(path);
   }
 };

--- a/src/mocks/api/external/timmew/index.ts
+++ b/src/mocks/api/external/timmew/index.ts
@@ -4,4 +4,6 @@ export { mockFindAccount } from './mockFindAccount';
 export { mockFindAccountUnexpectedResponseBody } from './mockFindAccountUnexpectedResponseBody';
 export { mockCreateTask } from './mockCreateTask';
 export { mockCreateTaskUnexpectedResponseBody } from './mockCreateTaskUnexpectedResponseBody';
+export { mockStopTask } from './mockStopTask';
+export { mockStopTaskUnexpectedResponseBody } from './mockStopTaskUnexpectedResponseBody';
 export { mockAccountUnAuthenticatedError } from './mockAccountUnAuthenticatedError';

--- a/src/mocks/api/external/timmew/mockStopTask.ts
+++ b/src/mocks/api/external/timmew/mockStopTask.ts
@@ -1,0 +1,23 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockStopTask: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      id: 1,
+      status: 'pending',
+      startAt: '2019-08-24T14:15:22Z',
+      endAt: '2019-08-24T16:15:22Z',
+      duration: 7200,
+      taskCategoryId: 1,
+    })
+  );

--- a/src/mocks/api/external/timmew/mockStopTaskUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockStopTaskUnexpectedResponseBody.ts
@@ -1,0 +1,18 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockStopTaskUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      taskCategoryId: null,
+    })
+  );


### PR DESCRIPTION
# issueURL

#53 

# この PR で対応する範囲 / この PR で対応しない範囲
- タスクの記録を停止するための API リクエストを実装します。
- コンポーネントへの反映は別 PR で実装します。

# Storybook の URL、 スクリーンショット

機能の実装だけなのでとくになし

# 変更点概要

タスクの計測を停止機能への API リクエスト機能及びテストコードを実装しました。
具体的には`/tasks/{taskId}/stop`へのリクエストに関する機能を実装しています。

# レビュアーに重点的にチェックして欲しい点

ソースコードにコメントします。
※個人的に実装についてもっと良い方法があるのではないか、と思う箇所があるため、Draftにしています。
→この[コメント](https://github.com/commew/timelogger-web/pull/92#discussion_r1262596839)についてです。
# 補足情報

