### PR TITLE
計測を終了する機能を実装した

### DIFF
--- a/src/api/client/fetch/__tests__/task/completeTask.spec.ts
+++ b/src/api/client/fetch/__tests__/task/completeTask.spec.ts
@@ -1,0 +1,87 @@
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { completeTask } from '@/api/client/fetch/task';
+import {
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  getDynamicBackendApiUrl,
+} from '@/features';
+import {
+  mockCompleteTask,
+  mockCompleteTaskUnexpectedResponseBody,
+  mockInternalServerError,
+} from '@/mocks';
+
+const mockHandlers = [
+  rest.patch(getDynamicBackendApiUrl('completeTask', '1'), mockCompleteTask),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+describe('src/api/client/fetch/task.ts completeTask TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  const mockAppToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwiZXhwIjoxNjgzNzMxMzIzLCJqdGkiOiIzNTY3ZGIyNy0zM2RlLTQyMTctOGM5Zi01ODhhYjVkMDdhZGQiLCJpYXQiOjE2ODExMzkzOTZ9.wV-4ftbM7EwPvyzoqWTNKaC1eZko3juJ84Q9C6X_dYs';
+
+  it('should be able to complete a task', async () => {
+    const completedTask = await completeTask({
+      taskId: 1,
+      appToken: mockAppToken,
+    });
+
+    const expected = {
+      id: 1,
+      status: 'completed',
+      startAt: '2019-08-24T14:15:22Z',
+      endAt: '2019-08-24T18:15:22Z',
+      duration: 14400,
+      taskCategoryId: 1,
+    };
+
+    expect(completedTask).toStrictEqual(expected);
+  });
+
+  it('should InvalidResponseBodyError Throw, because unexpected response body', async () => {
+    mockServer.use(
+      rest.patch(
+        getDynamicBackendApiUrl('completeTask', '1'),
+        mockCompleteTaskUnexpectedResponseBody
+      )
+    );
+
+    const dto = {
+      taskId: 1,
+      appToken: mockAppToken,
+    } as const;
+
+    await expect(completeTask(dto)).rejects.toThrow(InvalidResponseBodyError);
+  });
+
+  it('should UnexpectedFeatureError Throw, because http status is not ok', async () => {
+    mockServer.use(
+      rest.patch(
+        getDynamicBackendApiUrl('completeTask', '1'),
+        mockInternalServerError
+      )
+    );
+
+    const dto = {
+      taskId: 1,
+      appToken: mockAppToken,
+    } as const;
+
+    await expect(completeTask(dto)).rejects.toThrow(UnexpectedFeatureError);
+  });
+});

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -3,6 +3,7 @@ import type {
   Tasks,
   CreateTask,
   StopTask,
+  CompleteTask,
   FetchTasksRecording,
 } from '@/features';
 import {
@@ -76,6 +77,40 @@ export const stopTask: StopTask = async (dto) => {
   if (response.status !== httpStatusCode.ok) {
     throw new UnexpectedFeatureError(
       `failed to createTask. status: ${
+        response.status
+      }, body: ${await response.text()}`
+    );
+  }
+
+  const task = (await response.json()) as Task;
+  if (!isTask(task)) {
+    throw new InvalidResponseBodyError(
+      `responseBody is not in the expected format. body: ${JSON.stringify(
+        task
+      )}`
+    );
+  }
+
+  return task;
+};
+
+export const completeTask: CompleteTask = async (dto) => {
+  const { taskId, appToken } = dto;
+
+  const response = await fetch(
+    getDynamicBackendApiUrl('completeTask', `${taskId}`),
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${appToken}`,
+        Prefer: 'code=200, example=ExampleSuccess',
+      },
+    }
+  );
+
+  if (response.status !== httpStatusCode.ok) {
+    throw new UnexpectedFeatureError(
+      `failed to completeTask. status: ${
         response.status
       }, body: ${await response.text()}`
     );

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -21,6 +21,7 @@ export type {
   Tasks,
   CreateTask,
   StopTask,
+  CompleteTask,
   FetchTasksRecording,
 } from './task';
 export {

--- a/src/features/task/index.ts
+++ b/src/features/task/index.ts
@@ -5,5 +5,6 @@ export type {
   Tasks,
   CreateTask,
   StopTask,
+  CompleteTask,
   FetchTasksRecording,
 } from './task';

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -13,6 +13,11 @@ type StopTaskDto = {
   appToken: string;
 };
 
+type CompleteTaskDto = {
+  taskId: number;
+  appToken: string;
+};
+
 type FetchTasksRecordingDto = {
   appToken: string;
 };
@@ -55,6 +60,7 @@ export const isRecordingTasks = (value: unknown): value is TaskRecording[] => {
 };
 export type CreateTask = (dto: CreateTaskDto) => Promise<Task>;
 export type StopTask = (dto: StopTaskDto) => Promise<Task>;
+export type CompleteTask = (dto: CompleteTaskDto) => Promise<Task>;
 export type FetchTasksRecording = (
   dto: FetchTasksRecordingDto
 ) => Promise<TaskRecording[]>;

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -112,12 +112,17 @@ type DynamicBackendApiPaths = {
     path: keyof Pick<paths, '/tasks/{taskId}/stop'>,
     param: string
   ) => string;
+  completeTask: (
+    path: keyof Pick<paths, '/tasks/{taskId}/complete'>,
+    param: string
+  ) => string;
 };
 
 type DynamicBackendApiPath = keyof DynamicBackendApiPaths;
 
 const dynamicBackendApiPaths: DynamicBackendApiPaths = {
   stopTask: (path, param) => path.replace('{taskId}', `${param}`),
+  completeTask: (path, param) => path.replace('{taskId}', `${param}`),
 };
 
 export const getDynamicBackendApiUrl = (
@@ -130,6 +135,14 @@ export const getDynamicBackendApiUrl = (
     case 'stopTask': {
       const apiPath = dynamicBackendApiPaths[path](
         '/tasks/{taskId}/stop',
+        param
+      );
+
+      return `${apiUrl}${apiPath}`;
+    }
+    case 'completeTask': {
+      const apiPath = dynamicBackendApiPaths[path](
+        '/tasks/{taskId}/complete',
         param
       );
 

--- a/src/mocks/api/external/timmew/index.ts
+++ b/src/mocks/api/external/timmew/index.ts
@@ -11,3 +11,5 @@ export { mockFetchTaskRecording } from './mockFetchTasksRecording';
 export { mockFetchTaskRecordingEmptyResponseBody } from './mockFetchTasksRecordingEmptyResponseBody';
 export { mockFetchTasksRecordingUnexpectedResponseBody } from './mockFetchTasksRecordingUnexpectedResponseBody';
 export { mockFetchTasksRecordingUnexpectedResponseBodyStatusPending } from './mockFetchTasksRecordingUnexpectedResponseBodyStatusPending';
+export { mockCompleteTask } from './mockCompleteTask';
+export { mockCompleteTaskUnexpectedResponseBody } from './mockCompleteTaskUnexpectedResponseBody';

--- a/src/mocks/api/external/timmew/mockCompleteTask.ts
+++ b/src/mocks/api/external/timmew/mockCompleteTask.ts
@@ -1,0 +1,23 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockCompleteTask: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      id: 1,
+      status: 'completed',
+      startAt: '2019-08-24T14:15:22Z',
+      endAt: '2019-08-24T18:15:22Z',
+      duration: 14400,
+      taskCategoryId: 1,
+    })
+  );

--- a/src/mocks/api/external/timmew/mockCompleteTaskUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockCompleteTaskUnexpectedResponseBody.ts
@@ -1,0 +1,23 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockCompleteTaskUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      id: null,
+      status: null,
+      startAt: null,
+      endAt: null,
+      duration: null,
+      taskCategoryId: null,
+    })
+  );


### PR DESCRIPTION
# issueURL

#57 

# この PR で対応する範囲 / この PR で対応しない範囲

- API リクエストのロジックを実装します
- TaskItem系のコンポーネントへの組み込みは別で対応します

# Storybook の URL、 スクリーンショット

API リクエストのロジックのみなのでスクショはありません。

# 変更点概要

`tasks/{taskId}/complete` エンドポイントへのリクエスト処理を実装しました。

# レビュアーに重点的にチェックして欲しい点

#92 で実装した stopTask と類似した実装になっているので、そこまで大きな論点はなさそうな認識です！
もし気になる点あればレビューコメントください🙏

# 補足情報

とくになし