### PR TITLE
completeTask のNext API Routes を実装した

### DIFF
--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -6,6 +6,7 @@ import {
   UnexpectedFeatureError,
 } from '@/features';
 import type {
+  CompleteTaskFromClient,
   CreateTaskFromClient,
   StopTaskFromClient,
   Task,
@@ -65,6 +66,45 @@ export const stopTask: StopTaskFromClient = async (dto) => {
   };
 
   const response = await fetch(getAppApiUrl('stopTask'), {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody.content['application/json']),
+  });
+
+  if (response.status !== httpStatusCode.ok) {
+    throw new UnexpectedFeatureError(
+      `failed to stopTask. status: ${
+        response.status
+      }, body: ${await response.text()}`
+    );
+  }
+
+  const task = (await response.json()) as Task;
+  if (!isTask(task)) {
+    throw new InvalidResponseBodyError(
+      `responseBody is not in the expected format. body: ${JSON.stringify(
+        task
+      )}`
+    );
+  }
+
+  return task;
+};
+
+export const completeTask: CompleteTaskFromClient = async (dto) => {
+  const { taskId } = dto;
+
+  const requestBody = {
+    content: {
+      'application/json': {
+        taskId,
+      },
+    },
+  };
+
+  const response = await fetch(getAppApiUrl('completeTask'), {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -21,6 +21,7 @@ export {
   isPendingTasks,
   isNextApiRequestBodyOfCreateTaskDto,
   isNextApiRequestBodyOfStopTaskDto,
+  isNextApiRequestBodyOfCompleteTaskDto,
 } from './task';
 export type {
   Task,

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -33,6 +33,7 @@ export type {
   StopTask,
   StopTaskFromClient,
   CompleteTask,
+  CompleteTaskFromClient,
   FetchTasksRecording,
   FetchPendingTasks,
 } from './task';

--- a/src/features/task/index.ts
+++ b/src/features/task/index.ts
@@ -16,6 +16,7 @@ export type {
   StopTask,
   StopTaskFromClient,
   CompleteTask,
+  CompleteTaskFromClient,
   FetchTasksRecording,
   FetchPendingTasks,
 } from './task';

--- a/src/features/task/index.ts
+++ b/src/features/task/index.ts
@@ -4,6 +4,7 @@ export {
   isPendingTasks,
   isNextApiRequestBodyOfCreateTaskDto,
   isNextApiRequestBodyOfStopTaskDto,
+  isNextApiRequestBodyOfCompleteTaskDto,
 } from './task';
 export type {
   Task,

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -31,6 +31,10 @@ type CompleteTaskDto = {
   appToken: string;
 };
 
+type NextApiRequestBodyOfCompleteTaskDto = {
+  taskId: number;
+};
+
 type FetchTasksRecordingDto = {
   appToken: string;
 };
@@ -85,6 +89,10 @@ const nextApiRequestBodyOfStopTaskDtoSchema = z.object({
   taskId: z.number(),
 });
 
+const nextApiRequestBodyOfCompleteTaskDtoSchema = z.object({
+  taskId: z.number(),
+});
+
 export const isTask = (value: unknown): value is Task => {
   const result = taskSchema.safeParse(value);
 
@@ -106,6 +114,11 @@ export const isNextApiRequestBodyOfStopTaskDto = (
   value: unknown
 ): value is NextApiRequestBodyOfStopTaskDto => {
   return nextApiRequestBodyOfStopTaskDtoSchema.safeParse(value).success;
+};
+export const isNextApiRequestBodyOfCompleteTaskDto = (
+  value: unknown
+): value is NextApiRequestBodyOfCompleteTaskDto => {
+  return nextApiRequestBodyOfCompleteTaskDtoSchema.safeParse(value).success;
 };
 export type CreateTask = (dto: CreateTaskDto) => Promise<Task>;
 export type CreateTaskFromClient = (

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -16,6 +16,7 @@ type NextApiRequestBodyOfCreateTaskDto = {
 
 type CreateTaskDtoFromClient = Omit<CreateTaskDto, 'appToken'>;
 type StopTaskDtoFromClient = Omit<StopTaskDto, 'appToken'>;
+type CompleteTaskDtoFromClient = Omit<CompleteTaskDto, 'appToken'>;
 
 type StopTaskDto = {
   taskId: number;
@@ -127,6 +128,9 @@ export type CreateTaskFromClient = (
 export type StopTask = (dto: StopTaskDto) => Promise<Task>;
 export type StopTaskFromClient = (dto: StopTaskDtoFromClient) => Promise<Task>;
 export type CompleteTask = (dto: CompleteTaskDto) => Promise<Task>;
+export type CompleteTaskFromClient = (
+  dto: CompleteTaskDtoFromClient
+) => Promise<Task>;
 export type FetchTasksRecording = (
   dto: FetchTasksRecordingDto
 ) => Promise<TaskRecording[]>;

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -70,11 +70,13 @@ export const appUrl = (): AppUrl => {
 type AppApiPaths = {
   tasks: '/api/tasks/create';
   stopTask: '/api/tasks/stop';
+  completeTask: '/api/tasks/complete';
 };
 
 const appApiPaths: AppApiPaths = {
   tasks: '/api/tasks/create',
   stopTask: '/api/tasks/stop',
+  completeTask: '/api/tasks/complete',
 };
 
 type AppApiPathName = keyof AppApiPaths;
@@ -87,7 +89,8 @@ export const getAppApiUrl = (
 
   switch (path) {
     case 'tasks':
-    case 'stopTask': {
+    case 'stopTask':
+    case 'completeTask': {
       const apiPath: AppApiPath = appApiPaths[path];
 
       return `${apiUrl}${apiPath}`;

--- a/src/pages/api/tasks/complete.ts
+++ b/src/pages/api/tasks/complete.ts
@@ -1,0 +1,53 @@
+import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth';
+import { completeTask } from '@/api/server/fetch/task';
+import {
+  httpStatusCode,
+  isNextApiRequestBodyOfCompleteTaskDto,
+} from '@/features';
+import type { Task } from '@/features';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+type ErrorData = {
+  type: string;
+  title: string;
+};
+
+const handler: NextApiHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<Task | ErrorData>
+) => {
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session) {
+    res.status(httpStatusCode.unauthorized).json({
+      type: 'UNAUTHENTICATED',
+      title: 'Please set appToken in Authorization Header.',
+    });
+
+    return;
+  }
+
+  try {
+    if (!isNextApiRequestBodyOfCompleteTaskDto(req.body)) {
+      res.status(httpStatusCode.badRequest).json({
+        type: 'BAD_REQUEST',
+        title: 'Invalid request body.',
+      });
+
+      return;
+    }
+
+    const completeTaskDto = { appToken: session.appToken, ...req.body };
+    const completedTask = await completeTask(completeTaskDto);
+
+    res.status(httpStatusCode.ok).json(completedTask);
+  } catch (error) {
+    res.status(httpStatusCode.internalServerError).json({
+      type: 'INTERNAL_SERVER_ERROR',
+      title: 'Internal Server Error.',
+    });
+  }
+};
+
+export default handler;


### PR DESCRIPTION
# issueURL

#101 

# この PR で対応する範囲 / この PR で対応しない範囲

- タスク完了用の Next API Route および、その Route で使用する型ガード関数の実装を行う
- タスク完了に関するフロント側のリクエスト処理の実装を行う
- fetch 系の処理については Next API Route の実装は行わない

# Storybook の URL、 スクリーンショット

API Route の実装なのでスクショはなし

# 変更点概要

createTask, stopTask は実装済みなので、 completeTask についても Next API Route を実装しました。
fetch系の処理は今の所 `getServerSideProps` で対応しているので API Route は実装せず、必要になった際に実装することにしました。
また、コードの追加量がそれほど多くないことから、 completeTask についてフロント側のリクエスト処理も実装してしまいました。
対応コミット：
4139f0bac36e2fba35c3a6d4f90afbe63df62c93
87045ec834118238593045f7d5ddab4b2315baef
9429194dba42f1a926ee41b083a1605f9f8893b3

# レビュアーに重点的にチェックして欲しい点

- Next API Routes について、下記の実装をもって現状必要なAPI Rotues は実装済みという認識で良いかどうか
  - createTask 
  - stopTask
  - completeTask <-今回の実装

# 補足情報

とくになし