### PR TITLE
タスク計測を終了する機能を実装した

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,7 @@ jobs:
   chromatic-deployment:
     name: Deploy Storybook to chromatic
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/src/components/CompleteTaskButton/CompleteTask.stories.tsx
+++ b/src/components/CompleteTaskButton/CompleteTask.stories.tsx
@@ -1,0 +1,16 @@
+import type { ComponentStoryObj } from '@storybook/react';
+import { CompleteTaskButton } from './CompleteTaskButton';
+
+const story = {
+  component: CompleteTaskButton,
+};
+
+export default story;
+
+type Story = ComponentStoryObj<typeof CompleteTaskButton>;
+
+export const Default: Story = {
+  args: {
+    taskId: 1,
+  },
+};

--- a/src/components/CompleteTaskButton/CompleteTaskButton.tsx
+++ b/src/components/CompleteTaskButton/CompleteTaskButton.tsx
@@ -21,7 +21,7 @@ export const CompleteTaskButton: FC<Props> = ({ taskId }) => {
 
   const handleError = useErrorHandler();
 
-  const clickHandler = (taksId: number) => async () => {
+  const clickHandler = async (taksId: number) => {
     try {
       const completeTaskDto = { taskId: taksId };
       const response = await completeTask(completeTaskDto);
@@ -40,7 +40,9 @@ export const CompleteTaskButton: FC<Props> = ({ taskId }) => {
       className={classes.button}
       styles={{ leftIcon: { marginRight: '0.5rem' } }}
       aria-label="COMPLETE"
-      onClick={clickHandler(taskId)}
+      onClick={async () => {
+        await clickHandler(taskId);
+      }}
     >
       <Text color="dark.6" fw={700} fz="xs">
         終了

--- a/src/components/CompleteTaskButton/CompleteTaskButton.tsx
+++ b/src/components/CompleteTaskButton/CompleteTaskButton.tsx
@@ -1,0 +1,50 @@
+import type { FC } from 'react';
+import { Button, createStyles, Text } from '@mantine/core';
+import { IconSquare } from '@tabler/icons-react';
+import { useErrorHandler } from 'react-error-boundary';
+import { completeTask } from '@/api/client/fetch/task';
+
+const useStyles = createStyles(() => ({
+  button: {
+    width: '80px',
+    height: '34px',
+    padding: '7px 10px',
+  },
+}));
+
+type Props = {
+  taskId: number;
+};
+
+export const CompleteTaskButton: FC<Props> = ({ taskId }) => {
+  const { classes, theme } = useStyles();
+
+  const handleError = useErrorHandler();
+
+  const clickHandler = (taksId: number) => async () => {
+    try {
+      const completeTaskDto = { taskId: taksId };
+      const response = await completeTask(completeTaskDto);
+      console.log(response); // TODO: レスポンスデータを元にレンダリングを変更する
+    } catch (error) {
+      handleError(error);
+    }
+  };
+
+  return (
+    <Button
+      leftIcon={
+        <IconSquare size="1rem" color={theme.colors.dark[6]} stroke={2.75} />
+      }
+      color="gray.4"
+      className={classes.button}
+      styles={{ leftIcon: { marginRight: '0.5rem' } }}
+      aria-label="COMPLETE"
+      onClick={clickHandler(taskId)}
+    >
+      <Text color="dark.6" fw={700} fz="xs">
+        終了
+      </Text>
+    </Button>
+  );
+};

--- a/src/components/CompleteTaskButton/index.ts
+++ b/src/components/CompleteTaskButton/index.ts
@@ -1,0 +1,1 @@
+export { CompleteTaskButton } from './CompleteTaskButton';

--- a/src/components/MeasuringTaskItem/MeasuringTaskItem.tsx
+++ b/src/components/MeasuringTaskItem/MeasuringTaskItem.tsx
@@ -1,11 +1,7 @@
 import type { FC } from 'react';
 import { Box, Button, createStyles, Flex, Group, Text } from '@mantine/core';
-import {
-  IconPlayerPause,
-  IconHome,
-  IconSquare,
-  IconPlayerPlay,
-} from '@tabler/icons-react';
+import { IconPlayerPause, IconHome, IconPlayerPlay } from '@tabler/icons-react';
+import { CompleteTaskButton } from '../CompleteTaskButton/CompleteTaskButton';
 
 const useStyles = createStyles((theme) => ({
   button: {
@@ -102,23 +98,7 @@ export const MeasuringTaskItem: FC<Props> = ({
             </Text>
           </Button>
         )}
-        <Button
-          leftIcon={
-            <IconSquare
-              size="1rem"
-              color={theme.colors.dark[6]}
-              stroke={2.75}
-            />
-          }
-          color="gray.4"
-          className={classes.button}
-          styles={{ leftIcon: { marginRight: '0.5rem' } }}
-          aria-label="COMPLETE"
-        >
-          <Text color="dark.6" fw={700} fz="xs">
-            終了
-          </Text>
-        </Button>
+        <CompleteTaskButton taskId={1} />
       </Group>
     </Flex>
   );

--- a/src/components/StoppedTaskItem/StoppedTaskItem.tsx
+++ b/src/components/StoppedTaskItem/StoppedTaskItem.tsx
@@ -1,11 +1,7 @@
 import type { FC } from 'react';
 import { Box, Button, createStyles, Flex, Group, Text } from '@mantine/core';
-import {
-  IconPlayerPause,
-  IconHome,
-  IconSquare,
-  IconPlayerPlay,
-} from '@tabler/icons-react';
+import { IconPlayerPause, IconHome, IconPlayerPlay } from '@tabler/icons-react';
+import { CompleteTaskButton } from '@/components/CompleteTaskButton';
 
 const useStyles = createStyles((theme) => ({
   button: {
@@ -102,23 +98,7 @@ export const StoppedTaskItem: FC<Props> = ({
             </Text>
           </Button>
         )}
-        <Button
-          leftIcon={
-            <IconSquare
-              size="1rem"
-              color={theme.colors.dark[6]}
-              stroke={2.75}
-            />
-          }
-          color="gray.4"
-          className={classes.button}
-          styles={{ leftIcon: { marginRight: '0.5rem' } }}
-          aria-label="COMPLETE"
-        >
-          <Text color="dark.6" fw={700} fz="xs">
-            終了
-          </Text>
-        </Button>
+        <CompleteTaskButton taskId={1} />
       </Group>
     </Flex>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,3 +7,4 @@ export { SideBar } from './SideBar';
 export { TaskMeasurementCategoryButton } from './TaskMeasurementCategoryButton';
 export { MeasuringTaskItem } from './MeasuringTaskItem';
 export { StoppedTaskItem } from './StoppedTaskItem';
+export { CompleteTaskButton } from './CompleteTaskButton';


### PR DESCRIPTION
# issueURL

#57 

# この PR で対応する範囲 / この PR で対応しない範囲

- タスク計測を終了する機能を持ったボタンコンポーネントを実装する
- タスク終了後のレンダリング処理は本PRでは実装しない

# Storybook の URL、 スクリーンショット

https://63d52217f1430a5ad69846cd-idopnirikl.chromatic.com/?path=/story/components-completetaskbutton-completetask--default

# 変更点概要

#101 で実装した Next API Routes を経由するリクエスト処理を用いてタスク完了機能を実装しました。
なお、今回の実装で終了ボタンをタスクアイテムコンポーネントから切り出して、終了ボタンコンポーネントを実装する形にしています。

# レビュアーに重点的にチェックして欲しい点

今のタスクアイテムコンポーネント（ `MeasuringTaskItem` / `StoppedTaskItem` ）は現状役割を持ちすぎているように感じました👀
なので、タスクを終了する機能を実装すると同時にそのUIを別のコンポーネントに切り出しました。

この方針で問題なさそうであれば、以下のコンポーネントを実装するイシューを作成し、対応していこうと思います！
- タスク計測再開ボタン
- タスク計測停止ボタン

また、これを機に以前言及されていた `MeasuringTaskItem` / `StoppedTaskItem` を統合し、 `TaskItem`にまとめてしまおうかと考えています！（これは~~別イシュー~~ #81 で対応）

上記について、もしご意見あればお伺いしたいです🙏
どうぞよろしくお願いしますー！

# 補足情報
4d9628ccc807f14b721a1a357cace2c035345887　のコミットについて、chromatic のビルドがこけているようなので原因を調査する必要があります