### PR TITLE
現状アカウント名は不要なのでAPIの定義から削除する事にしました

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,7 @@ jobs:
   chromatic-deployment:
     name: Deploy Storybook to chromatic
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/public/docs/api/openapi.yaml
+++ b/public/docs/api/openapi.yaml
@@ -25,7 +25,6 @@ paths:
                 ExampleSuccess:
                   value:
                     id: 1
-                    name: NekoKoneko
                     openIdProviders:
                       - sub: '10769150350006150715113082367'
                         provider: google
@@ -90,7 +89,6 @@ paths:
                 ExampleSuccess:
                   value:
                     id: 1
-                    name: NekoKoneko
                     openIdProviders:
                       - sub: '10769150350006150715113082367'
                         provider: google
@@ -784,12 +782,10 @@ components:
       description: アカウント
       examples:
         - id: 1
-          name: NekoKoneko
           openIdProviders:
             - sub: '10769150350006150715113082367'
               provider: google
         - id: 2
-          name: MyCat
           openIdProviders:
             - sub: '999999999999999999999999999'
               provider: google
@@ -800,9 +796,6 @@ components:
           type: number
           minimum: 1
           description: アカウントの識別子
-        name:
-          type: string
-          description: アカウント名
         openIdProviders:
           type: array
           items:
@@ -810,7 +803,6 @@ components:
       additionalProperties: false
       required:
         - id
-        - name
         - openIdProviders
     OpenIdProvider:
       title: OpenIdProvider

--- a/src/features/account/account.ts
+++ b/src/features/account/account.ts
@@ -19,7 +19,6 @@ export type Account = components['schemas']['Account'] & {
 
 const accountSchema = z.object({
   id: z.number(),
-  name: z.string(),
   openIdProviders: z.array(oidcProviderSchema),
 });
 

--- a/src/openapi/schema.ts
+++ b/src/openapi/schema.ts
@@ -82,8 +82,6 @@ export interface components {
     Account: {
       /** @description アカウントの識別子 */
       id: number;
-      /** @description アカウント名 */
-      name: string;
       openIdProviders: (components["schemas"]["OpenIdProvider"])[];
     };
     /**


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/83

# この PR で対応する範囲 / この PR で対応しない範囲

## この PR で対応する範囲

https://github.com/commew/timelogger-web/issues/83 に記載があるようにアカウント名OpenAPIの定義から削除する為の対応を実施します。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし

# 変更点概要

タイトルの通りですが、https://github.com/commew/timelogger-web/issues/83 で不要という結論が出たのでOpenAPIの定義からアカウント名を削除しました。

以下が対象のAPI仕様書のURLになります。

https://timelogger-web-git-feature-issue83-commew.vercel.app/docs/api#/operations/getAccounts

https://timelogger-web-git-feature-issue83-commew.vercel.app/docs/api#/operations/postAccounts

https://timelogger-web-git-feature-issue83-commew.vercel.app/docs/api#/schemas/Account

# レビュアーに重点的にチェックして欲しい点

@c501306014 @stkzk3110 

情報共有のため、レビュアーに設定させて頂いております！軽微な変更なのと、バックエンドのブロッカーになってしまっているので先行してマージさせて頂きます🙏

@HaruyaFujimoto 遅くなって申し訳ありません、対応しました！

# 補足情報

このPRの内容とは直接関係ないですが、最近chromatic のWorkflowのタイムアウトが多いので以下のCommitでタイムアウトを延長しました。

https://github.com/commew/timelogger-web/pull/107/commits/61740b3cb2a5cfb655f3c374ffb42ed8a5797468

ちなみにここだけでなく私の個人プロジェクトや自分が仕事で参加しているプロジェクトでも同じような事が起きているので、chromatic側の問題だと思われます。