### PR TITLE
Task のスキーマに taskGroupId を追加した

### DIFF
--- a/public/docs/api/openapi.yaml
+++ b/public/docs/api/openapi.yaml
@@ -315,6 +315,7 @@ paths:
                     startAt: '2019-08-24T14:15:22Z'
                     endAt: '0000-00-00T00:00:00Z'
                     duration: 0
+                    taskGroupId: 1
                     taskCategoryId: 1
         '401':
           description: Unauthorized
@@ -385,6 +386,8 @@ paths:
             schema:
               type: object
               properties:
+                taskGroupId:
+                  type: integer
                 taskCategoryId:
                   type: integer
                 status:
@@ -397,12 +400,14 @@ paths:
                   format: date-time
                   example: '2019-08-24T14:15:22Z'
               required:
+                - taskGroupId
                 - taskCategoryId
                 - status
                 - startAt
             examples:
               Example 1:
                 value:
+                  taskGroupId: 1
                   taskCategoryId: 1
                   status: recording
                   startAt: '2019-08-24T14:15:22Z'
@@ -435,6 +440,7 @@ paths:
                     startAt: '2019-08-24T14:15:22Z'
                     endAt: '2019-08-24T16:15:22Z'
                     duration: 7200
+                    taskGroupId: 1
                     taskCategoryId: 1
         '400':
           description: Bad Request
@@ -523,6 +529,7 @@ paths:
                     startAt: '2019-08-24T14:15:22Z'
                     endAt: '2019-08-24T18:15:22Z'
                     duration: 14400
+                    taskGroupId: 1
                     taskCategoryId: 1
         '400':
           description: Bad Request
@@ -616,18 +623,21 @@ paths:
                         startAt: '2019-08-24T14:15:22Z'
                         endAt: '2019-08-24T18:15:22Z'
                         duration: 14400
+                        taskGroupId: 1
                         taskCategoryId: 1
                       - id: 2
                         status: recording
                         startAt: '2019-08-24T14:15:22Z'
                         endAt: '2019-08-24T18:15:22Z'
                         duration: 14400
+                        taskGroupId: 1
                         taskCategoryId: 1
                       - id: 3
                         status: recording
                         startAt: '2019-08-24T14:15:22Z'
                         endAt: '2019-08-24T18:15:22Z'
                         duration: 14400
+                        taskGroupId: 1
                         taskCategoryId: 1
         '401':
           description: Unauthorized
@@ -709,18 +719,21 @@ paths:
                         startAt: '2019-08-24T14:15:22Z'
                         endAt: '2019-08-24T18:15:22Z'
                         duration: 14400
+                        taskGroupId: 1
                         taskCategoryId: 1
                       - id: 2
                         status: pending
                         startAt: '2019-08-24T14:15:22Z'
                         endAt: '2019-08-24T18:15:22Z'
                         duration: 14400
+                        taskGroupId: 1
                         taskCategoryId: 1
                       - id: 3
                         status: pending
                         startAt: '2019-08-24T14:15:22Z'
                         endAt: '2019-08-24T18:15:22Z'
                         duration: 14400
+                        taskGroupId: 1
                         taskCategoryId: 1
         '401':
           description: Unauthorized
@@ -979,6 +992,7 @@ components:
           startAt: '2019-08-24T14:15:22Z'
           endAt: '2019-08-24T18:15:22Z'
           duration: 14400
+          taskGroupId: 1
           taskCategoryId: 1
       properties:
         id:
@@ -1009,17 +1023,25 @@ components:
           x-stoplight:
             id: zriewaxu80bi5
           description: タスクの実行時間（秒）
+        taskGroupId:
+          type: integer
+          x-stoplight:
+            id: 57stqbifuw4v3
+          description: TaskGroup のID
         taskCategoryId:
           type: integer
           x-stoplight:
             id: 57stqbifuw4v3
+          description: TaskCategory のID
       required:
         - id
         - status
         - startAt
         - endAt
         - duration
+        - taskGroupId
         - taskCategoryId
+      description: ''
   securitySchemes:
     Authorization:
       type: http

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -14,11 +14,12 @@ import type {
 import { type operations } from '@/openapi/schema';
 
 export const createTask: CreateTaskFromClient = async (dto) => {
-  const { taskCategoryId, status, startAt } = dto;
+  const { taskGroupId, taskCategoryId, status, startAt } = dto;
 
   const requestBody: operations['postTasks']['requestBody'] = {
     content: {
       'application/json': {
+        taskGroupId,
         taskCategoryId,
         status,
         startAt,

--- a/src/api/server/fetch/__tests__/task/completeTask.spec.ts
+++ b/src/api/server/fetch/__tests__/task/completeTask.spec.ts
@@ -47,6 +47,7 @@ describe('src/api/client/fetch/task.ts completeTask TestCases', () => {
       startAt: '2019-08-24T14:15:22Z',
       endAt: '2019-08-24T18:15:22Z',
       duration: 14400,
+      taskGroupId: 1,
       taskCategoryId: 1,
     };
 

--- a/src/api/server/fetch/__tests__/task/createTask.spec.ts
+++ b/src/api/server/fetch/__tests__/task/createTask.spec.ts
@@ -35,6 +35,7 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
 
   it('should be able to create a task', async () => {
     const createdTask = await createTask({
+      taskGroupId: 1,
       taskCategoryId: 1,
       status: 'recording',
       startAt: '2019-08-24T14:15:22Z',
@@ -47,6 +48,7 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
       startAt: '2019-08-24T14:15:22Z',
       endAt: '0000-00-00T00:00:00Z',
       duration: 0,
+      taskGroupId: 1,
       taskCategoryId: 1,
     };
 
@@ -59,6 +61,7 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
     );
 
     const dto = {
+      taskGroupId: 1,
       taskCategoryId: 1,
       status: 'recording',
       startAt: '2019-08-24T14:15:22Z',
@@ -74,6 +77,7 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
     );
 
     const dto = {
+      taskGroupId: 1,
       taskCategoryId: 1,
       status: 'recording',
       startAt: '2019-08-24T14:15:22Z',

--- a/src/api/server/fetch/__tests__/task/fetchPendingTasks.spec.ts
+++ b/src/api/server/fetch/__tests__/task/fetchPendingTasks.spec.ts
@@ -56,6 +56,7 @@ describe('src/api/client/fetch/task.ts fetchPendingTasks TestCases', () => {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
       {
@@ -64,6 +65,7 @@ describe('src/api/client/fetch/task.ts fetchPendingTasks TestCases', () => {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
       {
@@ -72,6 +74,7 @@ describe('src/api/client/fetch/task.ts fetchPendingTasks TestCases', () => {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
     ];
@@ -142,11 +145,11 @@ describe('src/api/client/fetch/task.ts fetchPendingTasks TestCases', () => {
   });
 
   it.each`
-    arg                                                                                                                                                                                                                                                                       | expected
-    ${[{ id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }]}                                                                                                                                     | ${true}
-    ${[{ id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }, { id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }]}   | ${true}
-    ${[{ id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }, { id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }]} | ${false}
-    ${[]}                                                                                                                                                                                                                                                                     | ${true}
+    arg                                                                                                                                                                                                                                                                                                       | expected
+    ${[{ id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }]}                                                                                                                                                     | ${true}
+    ${[{ id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }, { id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }]}   | ${true}
+    ${[{ id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }, { id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }]} | ${false}
+    ${[]}                                                                                                                                                                                                                                                                                                     | ${true}
   `(
     'should returns $expected when the input is $arg',
     ({ arg, expected }: TestTable) => {

--- a/src/api/server/fetch/__tests__/task/fetchTasksRecording.spec.ts
+++ b/src/api/server/fetch/__tests__/task/fetchTasksRecording.spec.ts
@@ -56,6 +56,7 @@ describe('src/api/client/fetch/task.ts fetchTasksRecording TestCases', () => {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
       {
@@ -64,6 +65,7 @@ describe('src/api/client/fetch/task.ts fetchTasksRecording TestCases', () => {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
       {
@@ -72,6 +74,7 @@ describe('src/api/client/fetch/task.ts fetchTasksRecording TestCases', () => {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
     ];
@@ -142,11 +145,11 @@ describe('src/api/client/fetch/task.ts fetchTasksRecording TestCases', () => {
   });
 
   it.each`
-    arg                                                                                                                                                                                                                                                                         | expected
-    ${[{ id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }]}                                                                                                                                     | ${true}
-    ${[{ id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }, { id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }]} | ${true}
-    ${[{ id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }, { id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskCategoryId: 1 }]}   | ${false}
-    ${[]}                                                                                                                                                                                                                                                                       | ${true}
+    arg                                                                                                                                                                                                                                                                                                         | expected
+    ${[{ id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }]}                                                                                                                                                     | ${true}
+    ${[{ id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }, { id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }]} | ${true}
+    ${[{ id: 1, status: 'recording', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }, { id: 1, status: 'pending', startAt: '2019-08-24T14:15:22Z', endAt: '2019-08-24T18:15:22Z', duration: 14400, taskGroupId: 1, taskCategoryId: 1 }]}   | ${false}
+    ${[]}                                                                                                                                                                                                                                                                                                       | ${true}
   `(
     'should returns $expected when the input is $arg',
     ({ arg, expected }: TestTable) => {

--- a/src/api/server/fetch/__tests__/task/stopTask.spec.ts
+++ b/src/api/server/fetch/__tests__/task/stopTask.spec.ts
@@ -47,6 +47,7 @@ describe('src/api/client/fetch/task.ts stopTask TestCases', () => {
       startAt: '2019-08-24T14:15:22Z',
       endAt: '2019-08-24T16:15:22Z',
       duration: 7200,
+      taskGroupId: 1,
       taskCategoryId: 1,
     };
 

--- a/src/api/server/fetch/task.ts
+++ b/src/api/server/fetch/task.ts
@@ -20,11 +20,12 @@ import {
 import { type operations } from '@/openapi/schema';
 
 export const createTask: CreateTask = async (dto) => {
-  const { taskCategoryId, status, startAt, appToken } = dto;
+  const { taskGroupId, taskCategoryId, status, startAt, appToken } = dto;
 
   const requestBody: operations['postTasks']['requestBody'] = {
     content: {
       'application/json': {
+        taskGroupId,
         taskCategoryId,
         status,
         startAt,

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { components } from '@/openapi/schema';
 
 type CreateTaskDto = {
+  taskGroupId: number;
   taskCategoryId: number;
   status: 'recording';
   startAt: string;
@@ -9,6 +10,7 @@ type CreateTaskDto = {
 };
 
 type NextApiRequestBodyOfCreateTaskDto = {
+  taskGroupId: number;
   taskCategoryId: number;
   status: 'recording';
   startAt: string;
@@ -65,6 +67,7 @@ const taskSchema = z.object({
   startAt: z.string(),
   endAt: z.string(),
   duration: z.number(),
+  taskGroupId: z.number(),
   taskCategoryId: z.number(),
 });
 
@@ -81,6 +84,7 @@ const pendingTaskSchema = taskSchema.extend({
 const pendingTasksSchema = z.array(pendingTaskSchema);
 
 const nextApiRequestBodyOfCreateTaskDtoSchema = z.object({
+  taskGroupId: z.number(),
   taskCategoryId: z.number(),
   status: z.literal('recording'),
   startAt: z.string(),

--- a/src/mocks/api/external/timmew/mockCompleteTask.ts
+++ b/src/mocks/api/external/timmew/mockCompleteTask.ts
@@ -18,6 +18,7 @@ export const mockCompleteTask: ResponseResolver<
       startAt: '2019-08-24T14:15:22Z',
       endAt: '2019-08-24T18:15:22Z',
       duration: 14400,
+      taskGroupId: 1,
       taskCategoryId: 1,
     })
   );

--- a/src/mocks/api/external/timmew/mockCompleteTaskUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockCompleteTaskUnexpectedResponseBody.ts
@@ -18,6 +18,7 @@ export const mockCompleteTaskUnexpectedResponseBody: ResponseResolver<
       startAt: null,
       endAt: null,
       duration: null,
+      taskGroupId: null,
       taskCategoryId: null,
     })
   );

--- a/src/mocks/api/external/timmew/mockCreateTask.ts
+++ b/src/mocks/api/external/timmew/mockCreateTask.ts
@@ -18,6 +18,7 @@ export const mockCreateTask: ResponseResolver<
       startAt: '2019-08-24T14:15:22Z',
       endAt: '0000-00-00T00:00:00Z',
       duration: 0,
+      taskGroupId: 1,
       taskCategoryId: 1,
     })
   );

--- a/src/mocks/api/external/timmew/mockCreateTaskUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockCreateTaskUnexpectedResponseBody.ts
@@ -18,6 +18,7 @@ export const mockCreateTaskUnexpectedResponseBody: ResponseResolver<
       startAt: null,
       endAt: null,
       duration: null,
+      taskGroupId: null,
       taskCategoryId: null,
     })
   );

--- a/src/mocks/api/external/timmew/mockFetchPendingTasks.ts
+++ b/src/mocks/api/external/timmew/mockFetchPendingTasks.ts
@@ -20,6 +20,7 @@ export const mockFetchPendingTasks: ResponseResolver<
           startAt: '2019-08-24T14:15:22Z',
           endAt: '2019-08-24T18:15:22Z',
           duration: 14400,
+          taskGroupId: 1,
           taskCategoryId: 1,
         },
         {
@@ -28,6 +29,7 @@ export const mockFetchPendingTasks: ResponseResolver<
           startAt: '2019-08-24T14:15:22Z',
           endAt: '2019-08-24T18:15:22Z',
           duration: 14400,
+          taskGroupId: 1,
           taskCategoryId: 1,
         },
         {
@@ -36,6 +38,7 @@ export const mockFetchPendingTasks: ResponseResolver<
           startAt: '2019-08-24T14:15:22Z',
           endAt: '2019-08-24T18:15:22Z',
           duration: 14400,
+          taskGroupId: 1,
           taskCategoryId: 1,
         },
       ],

--- a/src/mocks/api/external/timmew/mockFetchPendingTasksUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockFetchPendingTasksUnexpectedResponseBody.ts
@@ -20,6 +20,7 @@ export const mockFetchPendingTasksUnexpectedResponseBody: ResponseResolver<
           startAt: null,
           endAt: null,
           duration: null,
+          taskGroupId: null,
           taskCategoryId: null,
         },
       ],

--- a/src/mocks/api/external/timmew/mockFetchPendingTasksUnexpectedResponseBodyStatusRecording.ts
+++ b/src/mocks/api/external/timmew/mockFetchPendingTasksUnexpectedResponseBodyStatusRecording.ts
@@ -20,6 +20,7 @@ export const mockFetchPendingTasksUnexpectedResponseBodyStatusRecording: Respons
           startAt: '2019-08-24T14:15:22Z',
           endAt: '2019-08-24T18:15:22Z',
           duration: 14400,
+          taskGroupId: 1,
           taskCategoryId: 1,
         },
       ],

--- a/src/mocks/api/external/timmew/mockFetchTasksRecording.ts
+++ b/src/mocks/api/external/timmew/mockFetchTasksRecording.ts
@@ -20,6 +20,7 @@ export const mockFetchTaskRecording: ResponseResolver<
           startAt: '2019-08-24T14:15:22Z',
           endAt: '2019-08-24T18:15:22Z',
           duration: 14400,
+          taskGroupId: 1,
           taskCategoryId: 1,
         },
         {
@@ -28,6 +29,7 @@ export const mockFetchTaskRecording: ResponseResolver<
           startAt: '2019-08-24T14:15:22Z',
           endAt: '2019-08-24T18:15:22Z',
           duration: 14400,
+          taskGroupId: 1,
           taskCategoryId: 1,
         },
         {
@@ -36,6 +38,7 @@ export const mockFetchTaskRecording: ResponseResolver<
           startAt: '2019-08-24T14:15:22Z',
           endAt: '2019-08-24T18:15:22Z',
           duration: 14400,
+          taskGroupId: 1,
           taskCategoryId: 1,
         },
       ],

--- a/src/mocks/api/external/timmew/mockFetchTasksRecordingUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockFetchTasksRecordingUnexpectedResponseBody.ts
@@ -20,6 +20,7 @@ export const mockFetchTasksRecordingUnexpectedResponseBody: ResponseResolver<
           startAt: null,
           endAt: null,
           duration: null,
+          taskGroupId: null,
           taskCategoryId: null,
         },
       ],

--- a/src/mocks/api/external/timmew/mockFetchTasksRecordingUnexpectedResponseBodyStatusPending.ts
+++ b/src/mocks/api/external/timmew/mockFetchTasksRecordingUnexpectedResponseBodyStatusPending.ts
@@ -20,6 +20,7 @@ export const mockFetchTasksRecordingUnexpectedResponseBodyStatusPending: Respons
           startAt: '2019-08-24T14:15:22Z',
           endAt: '2019-08-24T18:15:22Z',
           duration: 14400,
+          taskGroupId: 1,
           taskCategoryId: 1,
         },
       ],

--- a/src/mocks/api/external/timmew/mockStopTask.ts
+++ b/src/mocks/api/external/timmew/mockStopTask.ts
@@ -18,6 +18,7 @@ export const mockStopTask: ResponseResolver<
       startAt: '2019-08-24T14:15:22Z',
       endAt: '2019-08-24T16:15:22Z',
       duration: 7200,
+      taskGroupId: 1,
       taskCategoryId: 1,
     })
   );

--- a/src/mocks/api/external/timmew/mockStopTaskUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockStopTaskUnexpectedResponseBody.ts
@@ -13,6 +13,12 @@ export const mockStopTaskUnexpectedResponseBody: ResponseResolver<
   res(
     ctx.status(httpStatusCode.ok),
     ctx.json({
+      id: null,
+      status: null,
+      startAt: null,
+      endAt: null,
+      duration: null,
+      taskGroupId: null,
       taskCategoryId: null,
     })
   );

--- a/src/openapi/schema.ts
+++ b/src/openapi/schema.ts
@@ -180,6 +180,9 @@ export interface components {
       endAt: string;
       /** @description タスクの実行時間（秒） */
       duration: number;
+      /** @description TaskGroup のID */
+      taskGroupId: number;
+      /** @description TaskCategory のID */
       taskCategoryId: number;
     };
   };
@@ -368,6 +371,7 @@ export interface operations {
     requestBody?: {
       content: {
         "application/json": {
+          taskGroupId: number;
           taskCategoryId: number;
           /**
            * @default recording 

--- a/src/templates/TimerTemplate/TimerTemplate.stories.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.stories.tsx
@@ -18,6 +18,7 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
       {
@@ -26,6 +27,7 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
       {
@@ -34,6 +36,7 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
     ],
@@ -44,6 +47,7 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
       {
@@ -52,6 +56,7 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
       {
@@ -60,6 +65,7 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
+        taskGroupId: 1,
         taskCategoryId: 1,
       },
     ],


### PR DESCRIPTION
# issueURL

#109 

# この PR で対応する範囲 / この PR で対応しない範囲

掲題の通り、openAPI の Task のスキーマに taskGroupId を追加し、それに関連する一連のソースコードを修正しました。

# Storybook の URL、 スクリーンショット

レンダリングに関する修正ではないので、スクリーンショットはなし

# 変更点概要

Task のスキーマに taskGroupId を追加しました。
また、それに伴い 型定義・モックサーバ・テストコードを修正しています。

# レビュアーに重点的にチェックして欲しい点

主に今回の変更（Task のスキーマに taskGroupId を追加）の妥当性をレビューしていただきたいです🙏
自分としては、 #109 に示したように、タスクが属するタスクグループ名を取得するために必要な変更だという認識です！
※ API エンドポイントに関する変更なので、周知のためバックエンドチームもレビュワーに入れさせていただいております！

# 補足情報

とくになし