### PR TITLE
タスクアイテムコンポーネントに時間計測ロジックを追加した

### DIFF
--- a/src/components/TaskItem/TaskItem.stories.tsx
+++ b/src/components/TaskItem/TaskItem.stories.tsx
@@ -13,6 +13,7 @@ export const Default: Story = {
   args: {
     categoryName: 'カテゴリ名',
     categoryGroupName: 'グループ名',
+    duration: 14400,
     status: 'recording',
   },
 };
@@ -21,6 +22,7 @@ export const Pending: Story = {
   args: {
     categoryName: 'カテゴリ名',
     categoryGroupName: 'グループ名',
+    duration: 14400,
     status: 'pending',
   },
 };

--- a/src/components/TaskItem/TaskItem.tsx
+++ b/src/components/TaskItem/TaskItem.tsx
@@ -7,6 +7,7 @@ import {
   CompleteTaskButton,
 } from '@/components';
 import { ExhaustiveError } from '@/features';
+import { useTaskTimer } from '@/hooks';
 
 const useStyles = createStyles((theme) => ({
   button: {
@@ -27,15 +28,19 @@ const useStyles = createStyles((theme) => ({
 type Props = {
   categoryName: string;
   categoryGroupName: string;
+  duration: number;
   status: 'recording' | 'pending' | 'completed';
 };
 
 export const TaskItem: FC<Props> = ({
   categoryName,
   categoryGroupName,
+  duration,
   status,
 }) => {
   const { classes, theme } = useStyles();
+
+  const time = useTaskTimer(duration, status);
 
   const renderChangeStatusButton = () => {
     switch (status) {
@@ -73,7 +78,7 @@ export const TaskItem: FC<Props> = ({
         <Box>
           <Text fz="sm">計測時間</Text>
           <Text color="dark.6" fz={theme.headings.sizes.h1.fontSize} fw={700}>
-            00:00:10 {/* TODO: ここは動的に値を変更できるようにする */}
+            {time}
           </Text>
         </Box>
       </Flex>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useTaskTimer } from './useTaskTimer';

--- a/src/hooks/useTaskTimer/__tests__/useTaskTimer.spec.ts
+++ b/src/hooks/useTaskTimer/__tests__/useTaskTimer.spec.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTaskTimer } from '@/hooks';
+
+describe('src/hooks/useTaskTimer/useTaskTimer.ts TestCases', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('should return the formatted time for recording status', () => {
+    const { result } = renderHook(() => useTaskTimer(0, 'recording'));
+
+    expect(result.current).toBe('00:00:00');
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe('00:00:01');
+  });
+
+  it('should return the formatted time for pending status', () => {
+    const { result } = renderHook(() => useTaskTimer(14410, 'pending'));
+
+    expect(result.current).toBe('04:00:10');
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current).toBe('04:00:10');
+  });
+
+  it('should return the formatted time for completed status', () => {
+    const { result } = renderHook(() => useTaskTimer(300, 'completed'));
+    expect(result.current).toBe('00:05:00');
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe('00:05:00');
+  });
+
+  it('should return the formatted time for very long time.', () => {
+    const { result } = renderHook(() => useTaskTimer(360000, 'completed')); // 100時間
+    expect(result.current).toBe('100:00:00');
+  });
+});

--- a/src/hooks/useTaskTimer/index.ts
+++ b/src/hooks/useTaskTimer/index.ts
@@ -1,0 +1,1 @@
+export { useTaskTimer } from './useTaskTimer';

--- a/src/hooks/useTaskTimer/useTaskTimer.ts
+++ b/src/hooks/useTaskTimer/useTaskTimer.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+import { ExhaustiveError } from '@/features';
+
+const timeCalculator = (time: number): string => {
+  const hour = Math.floor(time / 3600);
+  const minute = Math.floor((time % 3600) / 60);
+  const second = time % 60;
+
+  const hourStr = hour.toString().padStart(2, '0');
+  const minuteStr = minute.toString().padStart(2, '0');
+  const secondStr = second.toString().padStart(2, '0');
+  const formattedTime = `${hourStr}:${minuteStr}:${secondStr}`;
+
+  return formattedTime;
+};
+
+/**
+ * @param duration - タスクの時間
+ * @param status - タスクの状態
+ * @returns HH:MM:SS 形式の時間
+ * @description タスクの時間を HH:MM:SS 形式に変換する. タスクの状態が recording の場合はカウントが進むようにする.
+ */
+export const useTaskTimer = (
+  duration: number,
+  status: 'recording' | 'pending' | 'completed'
+): string => {
+  const [time, setTime] = useState(duration);
+
+  useEffect(() => {
+    let id: NodeJS.Timeout;
+
+    switch (status) {
+      case 'recording':
+        id = setInterval(() => {
+          setTime((t) => t + 1);
+        }, 1000);
+
+        return () => {
+          clearInterval(id);
+        };
+      case 'pending':
+      case 'completed':
+        return;
+      default:
+        throw new ExhaustiveError(status);
+    }
+  }, [status]);
+
+  return timeCalculator(time);
+};

--- a/src/templates/TimerTemplate/TimerTemplate.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.tsx
@@ -47,6 +47,7 @@ export const TimerTemplate: FC<Props> = ({ tasksRecording, pendingTasks }) => {
                 // TODO: カテゴリー名とカテゴリーグループ名を取得する処理を実装する
                 categoryName={'Category'}
                 categoryGroupName={'Category Group'}
+                duration={taskRecording.duration}
                 status={taskRecording.status}
               />
             );
@@ -73,6 +74,7 @@ export const TimerTemplate: FC<Props> = ({ tasksRecording, pendingTasks }) => {
                 // TODO: カテゴリー名とカテゴリーグループ名を取得する処理を実装する
                 categoryName={'Category'}
                 categoryGroupName={'Category Group'}
+                duration={pendingTask.duration}
                 status={pendingTask.status}
               />
             );


### PR DESCRIPTION
# issueURL

#81 

# この PR で対応する範囲 / この PR で対応しない範囲

タスクアイテムコンポーネントに時間計測ロジックを追加しました。
初回レンダリング時のステータスに応じて以下のように処理を実装しています。
- 計測中
時間が進むようにレンダリングを行う
- 停止中 または 終了
時間が止まった状態でレンダリングを行う
- その他
予期せぬステータスとして、ExhaustiveError をスローする

今回のPRではタイマーに関する停止・終了機能は実装しません。

# Storybook の URL、 スクリーンショット

![Aug-25-2023 20-56-34](https://github.com/commew/timelogger-web/assets/9443634/b2fae92b-b8a6-4c7f-9c1d-924c8e3b4160)

# 変更点概要

TODO で放置していたタスクアイテムコンポーネントの時間計測ロジックを追加しました。
最初はタイマーコンポーネントみたいな形で実装しようと思っていましたが、
ロジックの要素が強かったのでカスタムフックで実装しました。

# レビュアーに重点的にチェックして欲しい点

ソースコードにコメントで記載します。

# 補足情報

とくになし