### PR TITLE
タスクグループを取得する処理を実装した

### DIFF
--- a/src/api/server/fetch/__tests__/taskGroup/fetchTaskGroups.ts
+++ b/src/api/server/fetch/__tests__/taskGroup/fetchTaskGroups.ts
@@ -151,7 +151,7 @@ describe('src/api/server/fetch/taskGroup.ts fetchTaskGroups TestCases', () => {
     ${[{ id: 1, name: '仕事', categories: [{ id: 1, name: 'テスト' }, { id: 2, name: '設計' }] }]} | ${true}
     ${[{ id: 1, name: '仕事' }]}                                                                   | ${false}
     ${[{ id: 1, name: '仕事', categories: [{}] }]}                                                 | ${false}
-    ${[{ id: 1, name: '仕事', categories: [] }]}                                                   | ${true}
+    ${[{ id: 1, name: '仕事', categories: [] }]}                                                   | ${false}
     ${[]}                                                                                          | ${true}
   `(
     'should returns $expected when the input is $arg',

--- a/src/api/server/fetch/__tests__/taskGroup/fetchTaskGroups.ts
+++ b/src/api/server/fetch/__tests__/taskGroup/fetchTaskGroups.ts
@@ -1,0 +1,164 @@
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { fetchTaskGroups } from '@/api/server/fetch/taskGroup';
+import {
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  getBackendApiUrl,
+  isTaskGroups,
+} from '@/features';
+import type { TaskGroup } from '@/features';
+import {
+  mockInternalServerError,
+  mockFetchTaskGroups,
+  mockFetchTaskGroupsEmptyResponseBody,
+  mockFetchTaskGroupsUnexpectedResponseBody,
+} from '@/mocks';
+
+type TestTable = {
+  arg: unknown;
+  expected: boolean;
+};
+
+const mockHandlers = [
+  rest.get(getBackendApiUrl('taskGroups'), mockFetchTaskGroups),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+describe('src/api/server/fetch/taskGroup.ts fetchTaskGroups TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  const mockAppToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OSIsInByb3ZpZGVyIjoiZ29vZ2xlIiwiZXhwIjoxNjgzNzMxMzIzLCJqdGkiOiIzNTY3ZGIyNy0zM2RlLTQyMTctOGM5Zi01ODhhYjVkMDdhZGQiLCJpYXQiOjE2ODExMzkzOTZ9.wV-4ftbM7EwPvyzoqWTNKaC1eZko3juJ84Q9C6X_dYs';
+
+  it('should be able to fetch some task groups.', async () => {
+    const taskGroups = await fetchTaskGroups({
+      appToken: mockAppToken,
+    });
+
+    const expected = [
+      {
+        id: 1,
+        name: '仕事',
+        categories: [
+          {
+            id: 1,
+            name: '会議',
+          },
+          {
+            id: 2,
+            name: '資料作成',
+          },
+        ],
+      },
+      {
+        id: 2,
+        name: '学習',
+        categories: [
+          {
+            id: 3,
+            name: 'TOEIC',
+          },
+        ],
+      },
+      {
+        id: 3,
+        name: '趣味',
+        categories: [
+          {
+            id: 4,
+            name: '散歩',
+          },
+          {
+            id: 5,
+            name: '読書',
+          },
+        ],
+      },
+      {
+        id: 4,
+        name: 'グループ未分類',
+        categories: [
+          {
+            id: 6,
+            name: '移動・外出',
+          },
+        ],
+      },
+    ];
+
+    expect(taskGroups).toStrictEqual(expected);
+  });
+
+  it('should be able to fetch 0 task groups.', async () => {
+    mockServer.use(
+      rest.get(
+        getBackendApiUrl('taskGroups'),
+        mockFetchTaskGroupsEmptyResponseBody
+      )
+    );
+
+    const taskGroups = await fetchTaskGroups({
+      appToken: mockAppToken,
+    });
+
+    const expected: TaskGroup[] = [];
+    expect(taskGroups).toStrictEqual(expected);
+  });
+
+  it('should UnexpectedFeatureError Throw, because http status is not ok', async () => {
+    mockServer.use(
+      rest.get(getBackendApiUrl('taskGroups'), mockInternalServerError)
+    );
+
+    const dto = {
+      appToken: mockAppToken,
+    } as const;
+
+    await expect(fetchTaskGroups(dto)).rejects.toThrow(UnexpectedFeatureError);
+  });
+
+  it('should InvalidResponseBodyError Throw, because unexpected response body.', async () => {
+    mockServer.use(
+      rest.get(
+        getBackendApiUrl('taskGroups'),
+        mockFetchTaskGroupsUnexpectedResponseBody
+      )
+    );
+
+    const dto = {
+      appToken: mockAppToken,
+    } as const;
+    await expect(fetchTaskGroups(dto)).rejects.toThrow(
+      InvalidResponseBodyError
+    );
+  });
+
+  it.each`
+    arg                                                                                            | expected
+    ${[{ id: 1, name: '仕事', categories: [{ id: 1, name: 'テスト' }, { id: 2, name: '設計' }] }]} | ${true}
+    ${[{ id: 1, name: '仕事' }]}                                                                   | ${false}
+    ${[{ id: 1, name: '仕事', categories: [{}] }]}                                                 | ${false}
+    ${[{ id: 1, name: '仕事', categories: [] }]}                                                   | ${true}
+    ${[]}                                                                                          | ${true}
+  `(
+    'should returns $expected when the input is $arg',
+    ({ arg, expected }: TestTable) => {
+      const values = arg;
+
+      expect(isTaskGroups(values)).toBe(expected);
+    }
+  );
+});

--- a/src/api/server/fetch/taskGroup.ts
+++ b/src/api/server/fetch/taskGroup.ts
@@ -1,0 +1,47 @@
+import {
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  getBackendApiUrl,
+  httpStatusCode,
+  isTaskGroups,
+} from '@/features';
+import type {
+  FetchTaskGroups,
+  TaskGroups,
+} from '@/features/taskGroup/taskGroup';
+
+export const fetchTaskGroups: FetchTaskGroups = async (dto) => {
+  const { appToken } = dto;
+
+  const response = await fetch(getBackendApiUrl('getTaskGroups'), {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${appToken}`,
+      Prefer: 'code=200, example=ExampleSuccess',
+    },
+  });
+
+  if (response.status !== httpStatusCode.ok) {
+    throw new UnexpectedFeatureError(
+      `failed to fetchTasksRecording. status: ${
+        response.status
+      }, body: ${await response.text()}`
+    );
+  }
+
+  const fetchedTaskGroups = (await response.json()) as TaskGroups;
+
+  if (!fetchedTaskGroups.groups) return [];
+
+  const taskGroups = fetchedTaskGroups.groups;
+
+  if (!isTaskGroups(taskGroups)) {
+    throw new InvalidResponseBodyError(
+      `responseBody is not in the expected format( expected status is 'recording'. body: ${JSON.stringify(
+        taskGroups
+      )} )`
+    );
+  }
+
+  return taskGroups;
+};

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -37,6 +37,8 @@ export type {
   FetchTasksRecording,
   FetchPendingTasks,
 } from './task';
+export { isTaskGroups } from './taskGroup';
+export type { TaskGroup } from './taskGroup';
 export {
   InvalidResponseBodyError,
   UnexpectedFeatureError,

--- a/src/features/taskGroup/index.ts
+++ b/src/features/taskGroup/index.ts
@@ -1,0 +1,2 @@
+export { isTaskGroups } from './taskGroup';
+export type { TaskGroup } from './taskGroup';

--- a/src/features/taskGroup/taskGroup.ts
+++ b/src/features/taskGroup/taskGroup.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import type { components } from '@/openapi/schema';
+
+export type TaskGroup = components['schemas']['TaskGroup'];
+export type TaskGroups = {
+  groups?: TaskGroup[];
+};
+
+type FetchTaskGroupsDto = {
+  appToken: string;
+};
+
+const taskCategorySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+const taskGroupSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  categories: z.array(taskCategorySchema),
+});
+
+const taskGroupsSchema = z.array(taskGroupSchema);
+
+export const isTaskGroups = (value: unknown): value is TaskGroup[] => {
+  return taskGroupsSchema.safeParse(value).success;
+};
+
+export type FetchTaskGroups = (dto: FetchTaskGroupsDto) => Promise<TaskGroup[]>;

--- a/src/features/taskGroup/taskGroup.ts
+++ b/src/features/taskGroup/taskGroup.ts
@@ -18,7 +18,7 @@ const taskCategorySchema = z.object({
 const taskGroupSchema = z.object({
   id: z.number(),
   name: z.string(),
-  categories: z.array(taskCategorySchema),
+  categories: z.array(taskCategorySchema).nonempty(),
 });
 
 const taskGroupsSchema = z.array(taskGroupSchema);

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -107,6 +107,7 @@ type BackendApiPaths = {
   tasks: keyof Pick<paths, '/tasks'>;
   getTasksRecording: keyof Pick<paths, '/tasks/recording'>;
   getTasksPending: keyof Pick<paths, '/tasks/pending'>;
+  getTaskGroups: keyof Pick<paths, '/task-groups'>;
 };
 
 const backendApiPaths: BackendApiPaths = {
@@ -115,6 +116,7 @@ const backendApiPaths: BackendApiPaths = {
   tasks: '/tasks',
   getTasksRecording: '/tasks/recording',
   getTasksPending: '/tasks/pending',
+  getTaskGroups: '/task-groups',
 };
 
 type BackendApiPath = keyof BackendApiPaths;

--- a/src/mocks/api/external/timmew/index.ts
+++ b/src/mocks/api/external/timmew/index.ts
@@ -17,3 +17,6 @@ export { mockFetchPendingTasks } from './mockFetchPendingTasks';
 export { mockFetchPendingTasksEmptyResponseBody } from './mockFetchPendingTasksEmptyResponseBody';
 export { mockFetchPendingTasksUnexpectedResponseBody } from './mockFetchPendingTasksUnexpectedResponseBody';
 export { mockFetchPendingTasksUnexpectedResponseBodyStatusRecording } from './mockFetchPendingTasksUnexpectedResponseBodyStatusRecording';
+export { mockFetchTaskGroups } from './mockFetchTaskGroups';
+export { mockFetchTaskGroupsEmptyResponseBody } from './mockFetchTaskGroupsEmptyResponseBody';
+export { mockFetchTaskGroupsUnexpectedResponseBody } from './mockFetchTaskGroupsUnexpectedResponseBody';

--- a/src/mocks/api/external/timmew/mockFetchTaskGroups.ts
+++ b/src/mocks/api/external/timmew/mockFetchTaskGroups.ts
@@ -1,0 +1,67 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockFetchTaskGroups: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      groups: [
+        {
+          id: 1,
+          name: '仕事',
+          categories: [
+            {
+              id: 1,
+              name: '会議',
+            },
+            {
+              id: 2,
+              name: '資料作成',
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: '学習',
+          categories: [
+            {
+              id: 3,
+              name: 'TOEIC',
+            },
+          ],
+        },
+        {
+          id: 3,
+          name: '趣味',
+          categories: [
+            {
+              id: 4,
+              name: '散歩',
+            },
+            {
+              id: 5,
+              name: '読書',
+            },
+          ],
+        },
+        {
+          id: 4,
+          name: 'グループ未分類',
+          categories: [
+            {
+              id: 6,
+              name: '移動・外出',
+            },
+          ],
+        },
+      ],
+    })
+  );

--- a/src/mocks/api/external/timmew/mockFetchTaskGroupsEmptyResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockFetchTaskGroupsEmptyResponseBody.ts
@@ -1,0 +1,12 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockFetchTaskGroupsEmptyResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) => res(ctx.status(httpStatusCode.ok), ctx.json({}));

--- a/src/mocks/api/external/timmew/mockFetchTaskGroupsUnexpectedResponseBody.ts
+++ b/src/mocks/api/external/timmew/mockFetchTaskGroupsUnexpectedResponseBody.ts
@@ -1,0 +1,29 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockFetchTaskGroupsUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      groups: [
+        {
+          id: null,
+          name: null,
+          categories: [
+            {
+              id: null,
+              name: null,
+            },
+          ],
+        },
+      ],
+    })
+  );


### PR DESCRIPTION
# issueURL

#112 

# この PR で対応する範囲 / この PR で対応しない範囲

- タスクグループを取得するための処理を実装する
- 実装した処理を各コンポーネントで利用する処理は別PRで対応する

# Storybook の URL、 スクリーンショット

`getServerSideProps` での取得例
```typescript
  const fetchTaskGroupsDto = { appToken: session.appToken };
  const taskGroups = await fetchTaskGroups(fetchTaskGroupsDto);
  console.dir(taskGroups, { depth: null });
```
出力
```typescript
[
  {
    id: 1,
    name: '仕事',
    categories: [ { id: 1, name: '会議' }, { id: 2, name: '資料作成' } ]
  },
  { id: 2, name: '学習', categories: [ { id: 3, name: 'TOEIC' } ] },
  {
    id: 3,
    name: '趣味',
    categories: [ { id: 4, name: '散歩' }, { id: 5, name: '読書' } ]
  },
  { id: 4, name: 'グループ未分類', categories: [ { id: 6, name: '移動・外出' } ] }
]
```

# 変更点概要

タスクグループの取得処理を実装しました。

# レビュアーに重点的にチェックして欲しい点

ソースコードにコメントを追記します。

# 補足情報

ちょっと PR が大きくなってしまいました、すいません🙏