### PR TITLE
draft : /timer のタスク一覧のカテゴリ名、グループ名を取得・表示できるようにした

### DIFF
--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -37,7 +37,11 @@ export type {
   FetchTasksRecording,
   FetchPendingTasks,
 } from './task';
-export { isTaskGroups } from './taskGroup';
+export {
+  isTaskGroups,
+  findTaskGroupById,
+  findTaskCategoryById,
+} from './taskGroup';
 export type { TaskGroup } from './taskGroup';
 export {
   InvalidResponseBodyError,

--- a/src/features/taskGroup/index.ts
+++ b/src/features/taskGroup/index.ts
@@ -1,2 +1,6 @@
-export { isTaskGroups } from './taskGroup';
+export {
+  isTaskGroups,
+  findTaskGroupById,
+  findTaskCategoryById,
+} from './taskGroup';
 export type { TaskGroup } from './taskGroup';

--- a/src/features/taskGroup/taskGroup.ts
+++ b/src/features/taskGroup/taskGroup.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { components } from '@/openapi/schema';
 
+type TaskCategory = components['schemas']['TaskCategory'];
 export type TaskGroup = components['schemas']['TaskGroup'];
 export type TaskGroups = {
   groups?: TaskGroup[];
@@ -28,3 +29,27 @@ export const isTaskGroups = (value: unknown): value is TaskGroup[] => {
 };
 
 export type FetchTaskGroups = (dto: FetchTaskGroupsDto) => Promise<TaskGroup[]>;
+
+export const findTaskGroupById = (
+  taskGroups: TaskGroup[],
+  taskGroupId: number
+): TaskGroup | undefined => {
+  const taskGroup = taskGroups.find((taskGroup) => {
+    return taskGroupId === taskGroup.id;
+  });
+
+  return taskGroup;
+};
+
+export const findTaskCategoryById = (
+  taskGroups: TaskGroup[],
+  taskCategoryId: number
+): TaskCategory | undefined => {
+  const taskCategory = taskGroups
+    .flatMap((taskGroup) => taskGroup.categories)
+    .find((taskCategory) => {
+      return taskCategoryId === taskCategory.id;
+    });
+
+  return taskCategory;
+};

--- a/src/pages/timer.tsx
+++ b/src/pages/timer.tsx
@@ -4,21 +4,28 @@ import {
   fetchPendingTasks,
   fetchTasksRecording,
 } from '@/api/server/fetch/task';
-import type { PendingTask, TaskRecording } from '@/features';
+import type { PendingTask, TaskGroup, TaskRecording } from '@/features';
 import { appUrls } from '@/features';
 
 import { TimerTemplate } from '@/templates';
+import { fetchTaskGroups } from '../api/server/fetch/taskGroup';
 
 type Props = {
   tasksRecording: TaskRecording[];
   pendingTasks: PendingTask[];
+  taskGroups: TaskGroup[];
 };
 
-const TimerPage: NextPage<Props> = ({ tasksRecording, pendingTasks }) => {
+const TimerPage: NextPage<Props> = ({
+  tasksRecording,
+  pendingTasks,
+  taskGroups,
+}) => {
   return (
     <TimerTemplate
       tasksRecording={tasksRecording}
       pendingTasks={pendingTasks}
+      taskGroups={taskGroups}
     />
   );
 };
@@ -41,8 +48,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const fetchPendingTasksDto = { appToken: session.appToken };
   const pendingTasks = await fetchPendingTasks(fetchPendingTasksDto);
 
+  const fetchTaskGroupsDto = { appToken: session.appToken };
+  const taskGroups = await fetchTaskGroups(fetchTaskGroupsDto);
+
   return {
-    props: { tasksRecording, pendingTasks },
+    props: { tasksRecording, pendingTasks, taskGroups },
   };
 };
 

--- a/src/templates/TimerTemplate/TimerTemplate.stories.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.stories.tsx
@@ -27,8 +27,8 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
-        taskGroupId: 1,
-        taskCategoryId: 1,
+        taskGroupId: 2,
+        taskCategoryId: 3,
       },
       {
         id: 3,
@@ -36,8 +36,8 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
-        taskGroupId: 1,
-        taskCategoryId: 1,
+        taskGroupId: 3,
+        taskCategoryId: 4,
       },
     ],
     pendingTasks: [
@@ -47,8 +47,8 @@ export const Default: Story = {
         startAt: '2019-08-24T14:15:22Z',
         endAt: '2019-08-24T18:15:22Z',
         duration: 14400,
-        taskGroupId: 1,
-        taskCategoryId: 1,
+        taskGroupId: 4,
+        taskCategoryId: 6,
       },
       {
         id: 2,
@@ -67,6 +67,56 @@ export const Default: Story = {
         duration: 14400,
         taskGroupId: 1,
         taskCategoryId: 1,
+      },
+    ],
+    taskGroups: [
+      {
+        id: 1,
+        name: '仕事',
+        categories: [
+          {
+            id: 1,
+            name: '会議',
+          },
+          {
+            id: 2,
+            name: '資料作成',
+          },
+        ],
+      },
+      {
+        id: 2,
+        name: '学習',
+        categories: [
+          {
+            id: 3,
+            name: 'TOEIC',
+          },
+        ],
+      },
+      {
+        id: 3,
+        name: '趣味',
+        categories: [
+          {
+            id: 4,
+            name: '散歩',
+          },
+          {
+            id: 5,
+            name: '読書',
+          },
+        ],
+      },
+      {
+        id: 4,
+        name: 'グループ未分類',
+        categories: [
+          {
+            id: 6,
+            name: '移動・外出',
+          },
+        ],
       },
     ],
   },

--- a/src/templates/TimerTemplate/TimerTemplate.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.tsx
@@ -2,7 +2,12 @@ import type { FC } from 'react';
 import { Box, Stack, Title, createStyles } from '@mantine/core';
 import { IconPlayerPause, IconPlayerPlay } from '@tabler/icons-react';
 import { TaskItem } from '@/components';
-import type { PendingTask, TaskRecording } from '@/features';
+import {
+  findTaskCategoryById,
+  type PendingTask,
+  type TaskGroup,
+  type TaskRecording,
+} from '@/features';
 import { DefaultLayout } from '@/layouts';
 
 const useStyles = createStyles((theme) => ({
@@ -23,10 +28,27 @@ const useStyles = createStyles((theme) => ({
 type Props = {
   tasksRecording: TaskRecording[];
   pendingTasks: PendingTask[];
+  taskGroups: TaskGroup[];
 };
 
-export const TimerTemplate: FC<Props> = ({ tasksRecording, pendingTasks }) => {
+export const TimerTemplate: FC<Props> = ({
+  tasksRecording,
+  pendingTasks,
+  taskGroups,
+}) => {
   const { classes, theme } = useStyles();
+
+  const getTaskGroupName = (taskGroupId: number): string => {
+    const taskGroup = findTaskCategoryById(taskGroups, taskGroupId);
+
+    return taskGroup ? taskGroup.name : 'No Task Group';
+  };
+
+  const getTaskCategoryName = (taskCategoryId: number): string => {
+    const taskCategory = findTaskCategoryById(taskGroups, taskCategoryId);
+
+    return taskCategory ? taskCategory.name : 'No Task Category';
+  };
 
   return (
     <DefaultLayout>
@@ -44,9 +66,8 @@ export const TimerTemplate: FC<Props> = ({ tasksRecording, pendingTasks }) => {
             return (
               <TaskItem
                 key={index}
-                // TODO: カテゴリー名とカテゴリーグループ名を取得する処理を実装する
-                categoryName={'Category'}
-                categoryGroupName={'Category Group'}
+                categoryName={getTaskCategoryName(taskRecording.taskCategoryId)}
+                categoryGroupName={getTaskGroupName(taskRecording.taskGroupId)}
                 duration={taskRecording.duration}
                 status={taskRecording.status}
               />
@@ -71,9 +92,8 @@ export const TimerTemplate: FC<Props> = ({ tasksRecording, pendingTasks }) => {
             return (
               <TaskItem
                 key={index}
-                // TODO: カテゴリー名とカテゴリーグループ名を取得する処理を実装する
-                categoryName={'Category'}
-                categoryGroupName={'Category Group'}
+                categoryName={getTaskCategoryName(pendingTask.taskCategoryId)}
+                categoryGroupName={getTaskGroupName(pendingTask.taskGroupId)}
                 duration={pendingTask.duration}
                 status={pendingTask.status}
               />


### PR DESCRIPTION
# issueURL

#112 

# この PR で対応する範囲 / この PR で対応しない範囲

- API から取得した `taskGroups` から、タスクグループおよびタスクカテゴリーを検索できるようにした
- /timer に表示されるタスク一覧のタスクグループ名、カテゴリ名を動的に表示できるようにした
- サイドバーの表示に関する処理の実装は別ブランチで実装する

# Storybook の URL、 スクリーンショット



# 変更点概要

- `findTaskGroupById`, `findTaskCategoryById`メソッドを実装しました
`features/taskGroup` に find メソッドを実装し、 `taskGroups` からidを使ってタスクグループ・タスクカテゴリーを取得する処理実装しました。
- `pages/timer.tsx`の `getServerSideProps` で `taskGroups` をテンプレートに渡せるようにしました
- `template/TimerTemplate.tsx` で カテゴリ名・グループ名を取得し、 `TaskItem`コンポーネントに渡せるようにしました

# レビュアーに重点的にチェックして欲しい点

ソースコードにコメントを記載します。
> **Note**
まだ記載できていないので本PRのステータスを draft にしています！

# 補足情報

とくになし