### PR TITLE
タスクを停止状態から再開させるためのAPI設計を行った

### DIFF
--- a/public/docs/api/openapi.yaml
+++ b/public/docs/api/openapi.yaml
@@ -680,6 +680,22 @@ paths:
           in: header
           name: Request-Id
           description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                startAt:
+                  type: string
+                  format: date-time
+              required:
+                - startAt
+            examples:
+              Example 1:
+                value:
+                  startAt: '2019-08-24T14:15:22Z'
+        description: ''
   /tasks/recording:
     get:
       summary: 記録中のタスク一覧を取得する

--- a/public/docs/api/openapi.yaml
+++ b/public/docs/api/openapi.yaml
@@ -593,6 +593,93 @@ paths:
           description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
       security:
         - Authorization: []
+  '/tasks/{taskId}/start':
+    parameters:
+      - schema:
+          type: integer
+        name: taskId
+        in: path
+        required: true
+    patch:
+      summary: タスクの記録を再開する
+      operationId: patchTaskStartById
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+              examples:
+                ExampleSuccess:
+                  value:
+                    id: 1
+                    status: recording
+                    startAt: '2019-08-24T14:15:22Z'
+                    endAt: '2019-08-24T18:15:22Z'
+                    duration: 14400
+                    taskGroupId: 1
+                    taskCategoryId: 1
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleInvalidRequest:
+                  value:
+                    type: INVALID_STATUS_TRANSITION
+                    title: Invalid status transition.
+                    detail: Status is already recording.
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleUnAuthenticated:
+                  value:
+                    type: UNAUTHENTICATED
+                    title: Please set appToken in Authorization Header.
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleUnauthorized:
+                  value:
+                    type: UNAUTHORIZED
+                    title: Account is not authorized.
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              examples:
+                ExampleInternalServerError:
+                  value:
+                    type: INTERNAL_SERVER_ERROR
+                    title: Internal Server Error.
+      description: 停止状態のタスクの記録を再開するAPI
+      security:
+        - Authorization: []
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Authorization
+          description: Bearer + 半角スペース + JWT形式のトークンで指定する。
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Request-Id
+          description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
   /tasks/recording:
     get:
       summary: 記録中のタスク一覧を取得する

--- a/public/docs/api/openapi.yaml
+++ b/public/docs/api/openapi.yaml
@@ -696,6 +696,8 @@ paths:
                 value:
                   startAt: '2019-08-24T14:15:22Z'
         description: ''
+      tags:
+        - tasks
   /tasks/recording:
     get:
       summary: 記録中のタスク一覧を取得する

--- a/src/openapi/schema.ts
+++ b/src/openapi/schema.ts
@@ -55,6 +55,18 @@ export interface paths {
       };
     };
   };
+  "/tasks/{taskId}/start": {
+    /**
+     * タスクの記録を再開する 
+     * @description 停止状態のタスクの記録を再開するAPI
+     */
+    patch: operations["patchTaskStartById"];
+    parameters: {
+      path: {
+        taskId: number;
+      };
+    };
+  };
   "/tasks/recording": {
     /**
      * 記録中のタスク一覧を取得する 
@@ -477,6 +489,55 @@ export interface operations {
    * @description タスクの記録を終了するAPI
    */
   patchTaskCompleteById: {
+    parameters: {
+      header: {
+        /** @description Bearer + 半角スペース + JWT形式のトークンで指定する。 */
+        Authorization: string;
+        /** @description ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する */
+        "Request-Id"?: string;
+      };
+      path: {
+        taskId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Task"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetails"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetails"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetails"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetails"];
+        };
+      };
+    };
+  };
+  /**
+   * タスクの記録を再開する 
+   * @description 停止状態のタスクの記録を再開するAPI
+   */
+  patchTaskStartById: {
     parameters: {
       header: {
         /** @description Bearer + 半角スペース + JWT形式のトークンで指定する。 */

--- a/src/openapi/schema.ts
+++ b/src/openapi/schema.ts
@@ -549,6 +549,14 @@ export interface operations {
         taskId: number;
       };
     };
+    requestBody?: {
+      content: {
+        "application/json": {
+          /** Format: date-time */
+          startAt: string;
+        };
+      };
+    };
     responses: {
       /** @description OK */
       200: {


### PR DESCRIPTION
# issueURL

#79

# この PR で対応する範囲 / この PR で対応しない範囲

- openapi.yaml の更新を行う
- schema.ts の生成を行う
- フロントエンドの実装は行わない

# Storybook の URL、 スクリーンショット

APIドキュメント
https://timelogger-2vkuukkjv-commew.vercel.app/docs/api#/operations/patchTaskStartById

# 変更点概要

タスクの記録を再開するためのエンドポイント `/tasks/{taskId}/start` を追加しました。

# レビュアーに重点的にチェックして欲しい点

バックエンドチームの方でこのタスク待ちになっているタスクがあるようなので、
レビュワーに追加させていただきました🙏

レビューして欲しい内容についてはソースコードにコメントします。

# 補足情報

とくになし
