### PR TITLE
計測ページのサイドバーで、サーバから取得したタスクグループを表示できるようにした

### DIFF
--- a/src/components/SideBar/SideBar.stories.tsx
+++ b/src/components/SideBar/SideBar.stories.tsx
@@ -9,4 +9,57 @@ export default story;
 
 type Story = ComponentStoryObj<typeof SideBar>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    taskGroups: [
+      {
+        id: 1,
+        name: '仕事',
+        categories: [
+          {
+            id: 1,
+            name: '会議',
+          },
+          {
+            id: 2,
+            name: '資料作成',
+          },
+        ],
+      },
+      {
+        id: 2,
+        name: '学習',
+        categories: [
+          {
+            id: 3,
+            name: 'TOEIC',
+          },
+        ],
+      },
+      {
+        id: 3,
+        name: '趣味',
+        categories: [
+          {
+            id: 4,
+            name: '散歩',
+          },
+          {
+            id: 5,
+            name: '読書',
+          },
+        ],
+      },
+      {
+        id: 4,
+        name: 'グループ未分類',
+        categories: [
+          {
+            id: 6,
+            name: '移動・外出',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -9,6 +9,7 @@ import {
   createStyles,
 } from '@mantine/core';
 import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
+import type { TaskGroup } from '@/features';
 import { TaskMeasurementCategoryButton } from '../TaskMeasurementCategoryButton';
 
 const useStyles = createStyles((theme) => ({
@@ -36,44 +37,11 @@ const useStyles = createStyles((theme) => ({
   },
 }));
 
-type Category = Readonly<{
-  id: number;
-  name: string;
-}>;
+type Props = {
+  taskGroups: TaskGroup[];
+};
 
-type CategoryGroup = Readonly<{
-  id: number;
-  name: string;
-  categories: Category[];
-}>;
-
-// ここがAPIのレスポンス結果に置き変わるイメージ。
-const mockGroups: CategoryGroup[] = [
-  {
-    id: 1,
-    name: '仕事',
-    categories: [
-      { id: 1, name: '会議' },
-      { id: 2, name: '資料作成' },
-    ],
-  },
-  { id: 2, name: '学習', categories: [{ id: 3, name: 'TOEIC' }] },
-  {
-    id: 3,
-    name: '趣味',
-    categories: [
-      { id: 4, name: '散歩' },
-      { id: 5, name: '読書' },
-    ],
-  },
-  {
-    id: 4,
-    name: 'グループ未分類',
-    categories: [{ id: 6, name: '移動・外出' }],
-  },
-];
-
-export const SideBar: FC = () => {
+export const SideBar: FC<Props> = ({ taskGroups }) => {
   const { classes, theme } = useStyles();
   const [opened, setOpened] = useState<Record<string, boolean>>({});
   const ChevronIcon = theme.dir === 'ltr' ? IconChevronDown : IconChevronUp;
@@ -81,7 +49,7 @@ export const SideBar: FC = () => {
   return (
     <Navbar height={800} p="md" className={classes.navbar}>
       <Navbar.Section grow>
-        {mockGroups.map((group) => (
+        {taskGroups.map((group) => (
           <Group
             key={group.id}
             sx={{ rowGap: theme.spacing.xs, paddingBottom: theme.spacing.xs }}
@@ -123,8 +91,6 @@ export const SideBar: FC = () => {
             </Collapse>
           </Group>
         ))}
-        <TaskMeasurementCategoryButton name="カテゴリ名" />
-        <TaskMeasurementCategoryButton name="カテゴリ名" />
       </Navbar.Section>
     </Navbar>
   );

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -4,10 +4,12 @@ import Head from 'next/head';
 import { signOut } from 'next-auth/react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { HeaderMenu, TitleText, HeaderNavigation, SideBar } from '@/components';
+import type { TaskGroup } from '@/features';
 import { ErrorFallback } from '@/components/ErrorFallback/ErrorFallback';
 
 type Props = {
   children: ReactNode;
+  taskGroups: TaskGroup[];
 };
 
 const onError = (error: Error, info: { componentStack: string }) => {
@@ -35,7 +37,7 @@ const handleLogout = async (event: MouseEvent<HTMLButtonElement>) => {
 };
 
 // eslint-disable-next-line max-lines-per-function
-export const DefaultLayout: FC<Props> = ({ children }) => {
+export const DefaultLayout: FC<Props> = ({ children, taskGroups }) => {
   const { classes } = useStyles();
 
   return (
@@ -50,7 +52,7 @@ export const DefaultLayout: FC<Props> = ({ children }) => {
       <HeaderNavigation handleLogout={handleLogout}></HeaderNavigation>
       <Container size="xl">
         <div className={classes.layoutWrapper}>
-          <SideBar></SideBar>
+          <SideBar taskGroups={taskGroups} />
           <div className={classes.mainContent}>
             <TitleText title={title} />
             <HeaderMenu />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,20 @@
 import { Grid, Skeleton } from '@mantine/core';
 import type { NextPage, GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
+import { fetchTaskGroups } from '@/api/server/fetch/taskGroup';
 import { appUrls } from '@/features';
+import type { TaskGroup } from '@/features';
 import { DefaultLayout } from '@/layouts';
 
 const child = <Skeleton height={140} radius="md" animate={false} />;
 
-const IndexPage: NextPage = () => {
+type Props = {
+  taskGroups: TaskGroup[];
+};
+
+const IndexPage: NextPage<Props> = ({ taskGroups }) => {
   return (
-    <DefaultLayout>
+    <DefaultLayout taskGroups={taskGroups}>
       <Grid>
         <Grid.Col xs={4}>{child}</Grid.Col>
         <Grid.Col xs={8}>{child}</Grid.Col>
@@ -34,8 +40,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
+  const fetchTaskGroupsDto = { appToken: session.appToken };
+  const taskGroups = await fetchTaskGroups(fetchTaskGroupsDto);
+
   return {
-    props: {},
+    props: { taskGroups },
   };
 };
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,10 +1,16 @@
 import type { NextPage, GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
+import { fetchTaskGroups } from '@/api/server/fetch/taskGroup';
 import { appUrls } from '@/features';
+import type { TaskGroup } from '@/features';
 import { GitHubAccountSearchTemplate } from '@/templates';
 
-const SearchPage: NextPage = () => {
-  return <GitHubAccountSearchTemplate />;
+type Props = {
+  taskGroups: TaskGroup[];
+};
+
+const SearchPage: NextPage<Props> = ({ taskGroups }) => {
+  return <GitHubAccountSearchTemplate taskGroups={taskGroups} />;
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
@@ -18,9 +24,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       },
     };
   }
+  const fetchTaskGroupsDto = { appToken: session.appToken };
+  const taskGroups = await fetchTaskGroups(fetchTaskGroupsDto);
 
   return {
-    props: {},
+    props: { taskGroups },
   };
 };
 

--- a/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.stories.tsx
+++ b/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.stories.tsx
@@ -15,6 +15,57 @@ export default story;
 
 type Story = ComponentStoryObj<typeof GitHubAccountSearchTemplate>;
 
+const taskGroups = [
+  {
+    id: 1,
+    name: '仕事',
+    categories: [
+      {
+        id: 1,
+        name: '会議',
+      },
+      {
+        id: 2,
+        name: '資料作成',
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: '学習',
+    categories: [
+      {
+        id: 3,
+        name: 'TOEIC',
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: '趣味',
+    categories: [
+      {
+        id: 4,
+        name: '散歩',
+      },
+      {
+        id: 5,
+        name: '読書',
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: 'グループ未分類',
+    categories: [
+      {
+        id: 6,
+        name: '移動・外出',
+      },
+    ],
+  },
+];
+
 export const Default: Story = {
   parameters: {
     msw: {
@@ -23,6 +74,9 @@ export const Default: Story = {
       ],
     },
   },
+  args: {
+    taskGroups,
+  },
 };
 
 export const ShowGitHubAccountNotFoundError: Story = {
@@ -30,6 +84,9 @@ export const ShowGitHubAccountNotFoundError: Story = {
     msw: {
       handlers: [rest.get('https://api.github.com/users/*', mockNotFoundError)],
     },
+  },
+  args: {
+    taskGroups,
   },
 };
 
@@ -43,5 +100,8 @@ export const ShowUnexpectedResponseBodyError: Story = {
         ),
       ],
     },
+  },
+  args: {
+    taskGroups,
   },
 };

--- a/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.tsx
+++ b/src/templates/GitHubAccountSearchTemplate/GitHubAccountSearchTemplate.tsx
@@ -1,10 +1,15 @@
 import type { FC } from 'react';
 import { GitHubAccountSearch } from '@/components';
+import type { TaskGroup } from '@/features';
 import { DefaultLayout } from '@/layouts';
 
-export const GitHubAccountSearchTemplate: FC = () => {
+type Props = {
+  taskGroups: TaskGroup[];
+};
+
+export const GitHubAccountSearchTemplate: FC<Props> = ({ taskGroups }) => {
   return (
-    <DefaultLayout>
+    <DefaultLayout taskGroups={taskGroups}>
       <GitHubAccountSearch />
     </DefaultLayout>
   );

--- a/src/templates/TimerTemplate/TimerTemplate.stories.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.stories.tsx
@@ -9,6 +9,57 @@ export default story;
 
 type Story = ComponentStoryObj<typeof TimerTemplate>;
 
+const taskGroups = [
+  {
+    id: 1,
+    name: '仕事',
+    categories: [
+      {
+        id: 1,
+        name: '会議',
+      },
+      {
+        id: 2,
+        name: '資料作成',
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: '学習',
+    categories: [
+      {
+        id: 3,
+        name: 'TOEIC',
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: '趣味',
+    categories: [
+      {
+        id: 4,
+        name: '散歩',
+      },
+      {
+        id: 5,
+        name: '読書',
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: 'グループ未分類',
+    categories: [
+      {
+        id: 6,
+        name: '移動・外出',
+      },
+    ],
+  },
+];
+
 export const Default: Story = {
   args: {
     tasksRecording: [
@@ -69,56 +120,7 @@ export const Default: Story = {
         taskCategoryId: 1,
       },
     ],
-    taskGroups: [
-      {
-        id: 1,
-        name: '仕事',
-        categories: [
-          {
-            id: 1,
-            name: '会議',
-          },
-          {
-            id: 2,
-            name: '資料作成',
-          },
-        ],
-      },
-      {
-        id: 2,
-        name: '学習',
-        categories: [
-          {
-            id: 3,
-            name: 'TOEIC',
-          },
-        ],
-      },
-      {
-        id: 3,
-        name: '趣味',
-        categories: [
-          {
-            id: 4,
-            name: '散歩',
-          },
-          {
-            id: 5,
-            name: '読書',
-          },
-        ],
-      },
-      {
-        id: 4,
-        name: 'グループ未分類',
-        categories: [
-          {
-            id: 6,
-            name: '移動・外出',
-          },
-        ],
-      },
-    ],
+    taskGroups,
   },
 };
 
@@ -126,5 +128,6 @@ export const NoTasks: Story = {
   args: {
     tasksRecording: [],
     pendingTasks: [],
+    taskGroups,
   },
 };

--- a/src/templates/TimerTemplate/TimerTemplate.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.tsx
@@ -61,7 +61,7 @@ export const TimerTemplate: FC<Props> = ({
   };
 
   return (
-    <DefaultLayout>
+    <DefaultLayout taskGroups={taskGroups}>
       <Title order={2} className={classes.measuringHead} mt={'2rem'}>
         <IconPlayerPlay
           size="1.25rem"


### PR DESCRIPTION
# issueURL

#112 

# この PR で対応する範囲 / この PR で対応しない範囲

- 計測ページにてサーバで取得したタスクグループをサイドバーで表示できるようにした
- components/SideBar の Storybook にテスト用の args を設定した
- components/SideBar の jest のテストコードは今回は修正しない

# Storybook の URL、 スクリーンショット

- SideBar
https://63d52217f1430a5ad69846cd-gwxwaumqye.chromatic.com/?path=/story/components-sidebar--default
- TimerTemplate
https://63d52217f1430a5ad69846cd-gwxwaumqye.chromatic.com/?path=/story/templates-timertemplate--default

# 変更点概要
下記やり取りから、今回は「`pages/timer.tsx`の`getServerSideProps`で取得した`taskGroups`を`components/layouts/DefaultLayout.tsx`まで props で受け渡して実装」という手法を採用しました。
- https://github.com/commew/timelogger-web/issues/112#issuecomment-1708127018
- https://github.com/commew/timelogger-web/issues/112#issuecomment-1708355702
- https://github.com/commew/timelogger-web/issues/112#issuecomment-1708645995

# レビュアーに重点的にチェックして欲しい点

ソースコードにコメントで記載します！

# 補足情報

本タスクの目的とは直接関係ありませんが、今回の変更で影響を受けた`pages/index.tsx`, `pages/search.tsx`もSideBar表示用にコードを修正しています！