### PR TITLE
計測開始・計測再開のAPIの定義から RequestBody の startAt を削除した

### DIFF
--- a/public/docs/api/openapi.yaml
+++ b/public/docs/api/openapi.yaml
@@ -395,22 +395,16 @@ paths:
                   default: recording
                   example: recording
                   pattern: recording
-                startAt:
-                  type: string
-                  format: date-time
-                  example: '2019-08-24T14:15:22Z'
               required:
                 - taskGroupId
                 - taskCategoryId
                 - status
-                - startAt
             examples:
               Example 1:
                 value:
                   taskGroupId: 1
                   taskCategoryId: 1
                   status: recording
-                  startAt: '2019-08-24T14:15:22Z'
         description: ''
       security:
         - Authorization: []
@@ -680,22 +674,6 @@ paths:
           in: header
           name: Request-Id
           description: ユニークなID、リクエスト側からこれを指定した場合はレスポンス時にそのまま返ってくる、指定されない場合はAPI側で生成する
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                startAt:
-                  type: string
-                  format: date-time
-              required:
-                - startAt
-            examples:
-              Example 1:
-                value:
-                  startAt: '2019-08-24T14:15:22Z'
-        description: ''
       tags:
         - tasks
   /tasks/recording:

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -14,7 +14,7 @@ import type {
 import { type operations } from '@/openapi/schema';
 
 export const createTask: CreateTaskFromClient = async (dto) => {
-  const { taskGroupId, taskCategoryId, status, startAt } = dto;
+  const { taskGroupId, taskCategoryId, status } = dto;
 
   const requestBody: operations['postTasks']['requestBody'] = {
     content: {
@@ -22,7 +22,6 @@ export const createTask: CreateTaskFromClient = async (dto) => {
         taskGroupId,
         taskCategoryId,
         status,
-        startAt,
       },
     },
   };

--- a/src/api/server/fetch/__tests__/task/createTask.spec.ts
+++ b/src/api/server/fetch/__tests__/task/createTask.spec.ts
@@ -38,7 +38,6 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
       taskGroupId: 1,
       taskCategoryId: 1,
       status: 'recording',
-      startAt: '2019-08-24T14:15:22Z',
       appToken: mockAppToken,
     });
 
@@ -64,7 +63,6 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
       taskGroupId: 1,
       taskCategoryId: 1,
       status: 'recording',
-      startAt: '2019-08-24T14:15:22Z',
       appToken: mockAppToken,
     } as const;
 
@@ -80,7 +78,6 @@ describe('src/api/client/fetch/task.ts createTask TestCases', () => {
       taskGroupId: 1,
       taskCategoryId: 1,
       status: 'recording',
-      startAt: '2019-08-24T14:15:22Z',
       appToken: mockAppToken,
     } as const;
 

--- a/src/api/server/fetch/task.ts
+++ b/src/api/server/fetch/task.ts
@@ -20,7 +20,7 @@ import {
 import { type operations } from '@/openapi/schema';
 
 export const createTask: CreateTask = async (dto) => {
-  const { taskGroupId, taskCategoryId, status, startAt, appToken } = dto;
+  const { taskGroupId, taskCategoryId, status, appToken } = dto;
 
   const requestBody: operations['postTasks']['requestBody'] = {
     content: {
@@ -28,7 +28,6 @@ export const createTask: CreateTask = async (dto) => {
         taskGroupId,
         taskCategoryId,
         status,
-        startAt,
       },
     },
   };

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -5,7 +5,6 @@ type CreateTaskDto = {
   taskGroupId: number;
   taskCategoryId: number;
   status: 'recording';
-  startAt: string;
   appToken: string;
 };
 
@@ -13,7 +12,6 @@ type NextApiRequestBodyOfCreateTaskDto = {
   taskGroupId: number;
   taskCategoryId: number;
   status: 'recording';
-  startAt: string;
 };
 
 type CreateTaskDtoFromClient = Omit<CreateTaskDto, 'appToken'>;
@@ -87,7 +85,6 @@ const nextApiRequestBodyOfCreateTaskDtoSchema = z.object({
   taskGroupId: z.number(),
   taskCategoryId: z.number(),
   status: z.literal('recording'),
-  startAt: z.string(),
 });
 
 const nextApiRequestBodyOfStopTaskDtoSchema = z.object({

--- a/src/openapi/schema.ts
+++ b/src/openapi/schema.ts
@@ -390,11 +390,6 @@ export interface operations {
            * @example recording
            */
           status: string;
-          /**
-           * Format: date-time 
-           * @example 2019-08-24T14:15:22Z
-           */
-          startAt: string;
         };
       };
     };
@@ -547,14 +542,6 @@ export interface operations {
       };
       path: {
         taskId: number;
-      };
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          /** Format: date-time */
-          startAt: string;
-        };
       };
     };
     responses: {


### PR DESCRIPTION
# issueURL

#119 

# この PR で対応する範囲 / この PR で対応しない範囲

- 計測開始・計測再開のAPIの定義から RequestBody の startAt を削除する
- この削除に伴い、実装済みのフロントエンドの型定義およびリクエスト処理のDTOも併せて修正する

# Storybook の URL、 スクリーンショット

- storybook
https://63d52217f1430a5ad69846cd-ivuqycavic.chromatic.com/

- APIドキュメント
  - 計測開始： https://timelogger-6z60ndjb0-commew.vercel.app/docs/api#/operations/postTasks
  - 計測再開： https://timelogger-6z60ndjb0-commew.vercel.app/docs/api#/operations/patchTaskStartById

# 変更点概要

https://github.com/commew/timelogger-web/issues/119#issuecomment-1715619975 での議論から、 計測開始のリクエストボディに定義されていた startAt を削除することになったため、APIの定義から削除および、すでにフロントエンドで定義されていた処理群から startAt を削除しました。
※ 計測再開についてはまだ機能未実装のためソースコードの変更は不要です。

# レビュアーに重点的にチェックして欲しい点

特に問題ない認識ですが、念の為API設計が想定通りに変更されていることをご確認いただきたいです。

# 補足情報

特になし