### PR TITLE
フロントエンドからNextApi経由でタスク計測再開をリクエストする処理を実装した

### DIFF
--- a/src/api/client/fetch/__tests__/task/startTask.spec.ts
+++ b/src/api/client/fetch/__tests__/task/startTask.spec.ts
@@ -1,0 +1,78 @@
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { startTask } from '@/api/client/fetch/task';
+import {
+  InvalidResponseBodyError,
+  UnexpectedFeatureError,
+  getAppApiUrl,
+} from '@/features';
+import {
+  mockInternalServerError,
+  mockNextApiStartTask,
+  mockNextApiStartTaskUnexpectedResponseBody,
+} from '@/mocks';
+
+const mockHandlers = [
+  rest.patch(getAppApiUrl('startTask'), mockNextApiStartTask),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+describe('src/api/client/fetch/task.ts startTask TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  it('should be able to start a task', async () => {
+    const dto = { taskId: 1 } as const;
+    const startedTask = await startTask(dto);
+
+    const expected = {
+      id: 1,
+      status: 'recording',
+      startAt: '2019-08-24T14:15:22Z',
+      endAt: '2019-08-24T16:15:22Z',
+      duration: 7200,
+      taskGroupId: 1,
+      taskCategoryId: 1,
+    };
+
+    expect(startedTask).toStrictEqual(expected);
+  });
+
+  it('should InvalidResponseBodyError Throw, because unexpected response body', async () => {
+    mockServer.use(
+      rest.patch(
+        getAppApiUrl('startTask'),
+        mockNextApiStartTaskUnexpectedResponseBody
+      )
+    );
+
+    const dto = {
+      taskId: 1,
+    } as const;
+
+    await expect(startTask(dto)).rejects.toThrow(InvalidResponseBodyError);
+  });
+
+  it('should UnexpectedFeatureError Throw, because http status is not ok', async () => {
+    mockServer.use(
+      rest.patch(getAppApiUrl('startTask'), mockInternalServerError)
+    );
+
+    const dto = {
+      taskId: 1,
+    } as const;
+
+    await expect(startTask(dto)).rejects.toThrow(UnexpectedFeatureError);
+  });
+});

--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -8,6 +8,7 @@ import {
 import type {
   CompleteTaskFromClient,
   CreateTaskFromClient,
+  StartTaskFromClient,
   StopTaskFromClient,
   Task,
 } from '@/features';
@@ -37,6 +38,45 @@ export const createTask: CreateTaskFromClient = async (dto) => {
   if (response.status !== httpStatusCode.created) {
     throw new UnexpectedFeatureError(
       `failed to createTask. status: ${
+        response.status
+      }, body: ${await response.text()}`
+    );
+  }
+
+  const task = (await response.json()) as Task;
+  if (!isTask(task)) {
+    throw new InvalidResponseBodyError(
+      `responseBody is not in the expected format. body: ${JSON.stringify(
+        task
+      )}`
+    );
+  }
+
+  return task;
+};
+
+export const startTask: StartTaskFromClient = async (dto) => {
+  const { taskId } = dto;
+
+  const requestBody = {
+    content: {
+      'application/json': {
+        taskId,
+      },
+    },
+  };
+
+  const response = await fetch(getAppApiUrl('startTask'), {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody.content['application/json']),
+  });
+
+  if (response.status !== httpStatusCode.ok) {
+    throw new UnexpectedFeatureError(
+      `failed to startTask. status: ${
         response.status
       }, body: ${await response.text()}`
     );

--- a/src/components/StartTaskButton/StartTaskButton.tsx
+++ b/src/components/StartTaskButton/StartTaskButton.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import { Button, createStyles, Text } from '@mantine/core';
 import { IconPlayerPlay } from '@tabler/icons-react';
 import { useErrorHandler } from 'react-error-boundary';
+import { startTask } from '@/api/client/fetch/task';
 
 const useStyles = createStyles(() => ({
   button: {
@@ -20,10 +21,11 @@ export const StartTaskButton: FC<Props> = ({ taskId }) => {
 
   const handleError = useErrorHandler();
 
-  const clickHandler = (taksId: number) => {
+  const clickHandler = async (taksId: number) => {
     try {
-      // TODO: 停止したタスクを再開するAPIが実装されたらリクエスト処理を実装する
-      console.log(`${taksId}のタスクを再開します`);
+      const startTaskDto = { taskId: taksId };
+      const response = await startTask(startTaskDto);
+      console.log(response); // TODO 118 のイシューでレスポンスデータを元にレンダリングを変更する
     } catch (error) {
       handleError(error);
     }
@@ -42,8 +44,8 @@ export const StartTaskButton: FC<Props> = ({ taskId }) => {
       className={classes.button}
       styles={{ leftIcon: { marginRight: '0.5rem' } }}
       aria-label="START"
-      onClick={() => {
-        clickHandler(taskId);
+      onClick={async () => {
+        await clickHandler(taskId);
       }}
     >
       <Text color="gray.0" fz="xs" fw={700}>

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -30,6 +30,7 @@ export type {
   CreateTask,
   CreateTaskFromClient,
   StartTask,
+  StartTaskFromClient,
   StopTask,
   StopTaskFromClient,
   CompleteTask,

--- a/src/features/task/index.ts
+++ b/src/features/task/index.ts
@@ -15,6 +15,7 @@ export type {
   CreateTask,
   CreateTaskFromClient,
   StartTask,
+  StartTaskFromClient,
   StopTask,
   StopTaskFromClient,
   CompleteTask,

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -15,6 +15,7 @@ type NextApiRequestBodyOfCreateTaskDto = {
 };
 
 type CreateTaskDtoFromClient = Omit<CreateTaskDto, 'appToken'>;
+type StartTaskDtoFromClient = Omit<StartTaskDto, 'appToken'>;
 type StopTaskDtoFromClient = Omit<StopTaskDto, 'appToken'>;
 type CompleteTaskDtoFromClient = Omit<CompleteTaskDto, 'appToken'>;
 
@@ -145,6 +146,9 @@ export type CreateTaskFromClient = (
   dto: CreateTaskDtoFromClient
 ) => Promise<Task>;
 export type StartTask = (dto: StartTaskDto) => Promise<Task>;
+export type StartTaskFromClient = (
+  dto: StartTaskDtoFromClient
+) => Promise<Task>;
 export type StopTask = (dto: StopTaskDto) => Promise<Task>;
 export type StopTaskFromClient = (dto: StopTaskDtoFromClient) => Promise<Task>;
 export type CompleteTask = (dto: CompleteTaskDto) => Promise<Task>;

--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -69,12 +69,14 @@ export const appUrl = (): AppUrl => {
 
 type AppApiPaths = {
   tasks: '/api/tasks/create';
+  startTask: '/api/tasks/start';
   stopTask: '/api/tasks/stop';
   completeTask: '/api/tasks/complete';
 };
 
 const appApiPaths: AppApiPaths = {
   tasks: '/api/tasks/create',
+  startTask: '/api/tasks/start',
   stopTask: '/api/tasks/stop',
   completeTask: '/api/tasks/complete',
 };
@@ -89,6 +91,7 @@ export const getAppApiUrl = (
 
   switch (path) {
     case 'tasks':
+    case 'startTask':
     case 'stopTask':
     case 'completeTask': {
       const apiPath: AppApiPath = appApiPaths[path];

--- a/src/mocks/api/index.ts
+++ b/src/mocks/api/index.ts
@@ -1,2 +1,3 @@
+export * from './internal';
 export * from './external';
 export * from './error';

--- a/src/mocks/api/internal/index.ts
+++ b/src/mocks/api/internal/index.ts
@@ -1,0 +1,4 @@
+export {
+  mockNextApiStartTask,
+  mockNextApiStartTaskUnexpectedResponseBody,
+} from './task';

--- a/src/mocks/api/internal/task/index.ts
+++ b/src/mocks/api/internal/task/index.ts
@@ -1,0 +1,2 @@
+export { mockNextApiStartTask } from './mockNextApiStartTask';
+export { mockNextApiStartTaskUnexpectedResponseBody } from './mockNextApiStartTaskUnexpectedResponseBody';

--- a/src/mocks/api/internal/task/mockNextApiStartTask.ts
+++ b/src/mocks/api/internal/task/mockNextApiStartTask.ts
@@ -1,0 +1,24 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockNextApiStartTask: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      id: 1,
+      status: 'recording',
+      startAt: '2019-08-24T14:15:22Z',
+      endAt: '2019-08-24T16:15:22Z',
+      duration: 7200,
+      taskGroupId: 1,
+      taskCategoryId: 1,
+    })
+  );

--- a/src/mocks/api/internal/task/mockNextApiStartTaskUnexpectedResponseBody.ts
+++ b/src/mocks/api/internal/task/mockNextApiStartTaskUnexpectedResponseBody.ts
@@ -1,0 +1,24 @@
+import {
+  type ResponseResolver,
+  type MockedRequest,
+  type restContext,
+} from 'msw';
+
+import { httpStatusCode } from '@/features';
+
+export const mockNextApiStartTaskUnexpectedResponseBody: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      id: null,
+      status: null,
+      startAt: null,
+      endAt: null,
+      duration: null,
+      taskGroupId: null,
+      taskCategoryId: null,
+    })
+  );


### PR DESCRIPTION
# issueURL

#117 

# この PR で対応する範囲 / この PR で対応しない範囲

- フロントエンドからNextApi経由でタスク計測再開をリクエストするための処理を実装する
- 実際にタスク計測再開ボタンコンポーネントにリクエスト処理を組み込む
- UIへの反映は #118 で実装する
- /api/client/fetch のテストコードを実装する
  - startTask以外は別で issue を立てて対応する

# Storybook の URL、 スクリーンショット

https://63d52217f1430a5ad69846cd-qkmhelrtyy.chromatic.com/?path=/story/components-completetaskbutton-completetask--default

# 変更点概要

#128 での実装に引き続き、クライアントコンポーネント側からNextApi経由でタスク計測再開をリクエストする処理を実装し、実際にStartTaskButtonコンポーネントに組み込みました。

また、Complet, Stop の処理を実装した時に漏れていたクライアント側のテストコードも実装しました。
Issueの範囲から外れないように、とりあえず Start に関するテストコードのみを実装しています。

# レビュアーに重点的にチェックして欲しい点

ソースコード内に記載します。

# 補足情報

とくになし