### PR TITLE
計測開始機能をコンポーネントに組み込んだ

### DIFF
--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -84,6 +84,8 @@ export const SideBar: FC<Props> = ({ taskGroups }) => {
                 {group.categories.map((category) => (
                   <TaskMeasurementCategoryButton
                     key={category.id}
+                    groupId={group.id}
+                    categoryId={category.id}
                     name={category.name}
                   />
                 ))}

--- a/src/components/TaskMeasurementCategoryButton/TaskMeasurementCategoryButton.stories.tsx
+++ b/src/components/TaskMeasurementCategoryButton/TaskMeasurementCategoryButton.stories.tsx
@@ -12,5 +12,7 @@ type Story = ComponentStoryObj<typeof TaskMeasurementCategoryButton>;
 export const Default: Story = {
   args: {
     name: 'カテゴリ名',
+    groupId: 1,
+    categoryId: 1,
   },
 };

--- a/src/components/TaskMeasurementCategoryButton/TaskMeasurementCategoryButton.tsx
+++ b/src/components/TaskMeasurementCategoryButton/TaskMeasurementCategoryButton.tsx
@@ -3,6 +3,7 @@ import { createStyles, Box } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconHome } from '@tabler/icons-react';
 import Image from 'next/image';
+import { createTask } from '@/api/client/fetch/task';
 import hoveredImageSrc from './hover.webp';
 
 const useStyles = createStyles((theme) => ({
@@ -26,15 +27,35 @@ const useStyles = createStyles((theme) => ({
 }));
 
 type Props = {
+  groupId: number;
+  categoryId: number;
   name: string;
 };
 
-export const TaskMeasurementCategoryButton: FC<Props> = ({ name }) => {
+export const TaskMeasurementCategoryButton: FC<Props> = ({
+  groupId,
+  categoryId,
+  name,
+}) => {
   const { classes, theme } = useStyles();
   const { hovered, ref } = useHover();
 
+  const handleCreateTask = async () => {
+    const createdTask = await createTask({
+      taskGroupId: groupId,
+      taskCategoryId: categoryId,
+      status: 'recording',
+    });
+    console.log(createdTask); // TODO Issue 126で UI に反映する
+  };
+
   return (
-    <Box className={classes.button} ref={ref}>
+    <Box
+      className={classes.button}
+      ref={ref}
+      role="button"
+      onClick={handleCreateTask}
+    >
       <Box
         sx={{
           display: 'grid',
@@ -48,7 +69,6 @@ export const TaskMeasurementCategoryButton: FC<Props> = ({ name }) => {
       </Box>
       {hovered ? (
         <Image
-          role="button"
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           src={hoveredImageSrc}
           alt={'タスクの計測を開始'}


### PR DESCRIPTION
# issueURL

#126 

# この PR で対応する範囲 / この PR で対応しない範囲

- 計測開始機能をタスク計測開始ボタンのコンポーネントに組み込みました
- レスポンスデータの処理は #118 で対応します

# Storybook の URL、 スクリーンショット

※ 今回は見た目の変化はありません
https://63d52217f1430a5ad69846cd-dfspvserou.chromatic.com/?path=/story/components-taskmeasurementcategorybutton--default

# 変更点概要

`TaskMeasurementCategoryButton` コンポーネントに `creatTask`を実行するための処理を実装しました。

# レビュアーに重点的にチェックして欲しい点

ソースコードに記載します。

# 補足情報

とくになし