### PR TITLE
新規タスクの計測開始をUIに反映できるようにした

### DIFF
--- a/src/api/client/fetch/task.ts
+++ b/src/api/client/fetch/task.ts
@@ -2,6 +2,7 @@ import {
   getAppApiUrl,
   httpStatusCode,
   InvalidResponseBodyError,
+  isRecordingTask,
   isTask,
   UnexpectedFeatureError,
 } from '@/features';
@@ -11,6 +12,7 @@ import type {
   StartTaskFromClient,
   StopTaskFromClient,
   Task,
+  TaskRecording,
 } from '@/features';
 import { type operations } from '@/openapi/schema';
 
@@ -43,8 +45,8 @@ export const createTask: CreateTaskFromClient = async (dto) => {
     );
   }
 
-  const task = (await response.json()) as Task;
-  if (!isTask(task)) {
+  const task = (await response.json()) as TaskRecording;
+  if (!isRecordingTask(task)) {
     throw new InvalidResponseBodyError(
       `responseBody is not in the expected format. body: ${JSON.stringify(
         task

--- a/src/api/server/fetch/task.ts
+++ b/src/api/server/fetch/task.ts
@@ -7,6 +7,7 @@ import type {
   FetchTasksRecording,
   FetchPendingTasks,
   StartTask,
+  TaskRecording,
 } from '@/features';
 import {
   getBackendApiUrl,
@@ -14,6 +15,7 @@ import {
   InvalidResponseBodyError,
   UnexpectedFeatureError,
   isTask,
+  isRecordingTask,
   isRecordingTasks,
   isPendingTasks,
   getDynamicBackendApiUrl,
@@ -51,8 +53,8 @@ export const createTask: CreateTask = async (dto) => {
     );
   }
 
-  const task = (await response.json()) as Task;
-  if (!isTask(task)) {
+  const task = (await response.json()) as TaskRecording;
+  if (!isRecordingTask(task)) {
     throw new InvalidResponseBodyError(
       `responseBody is not in the expected format. body: ${JSON.stringify(
         task

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -9,7 +9,7 @@ import {
   createStyles,
 } from '@mantine/core';
 import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
-import type { TaskGroup } from '@/features';
+import type { TaskGroup, TaskRecording } from '@/features';
 import { TaskMeasurementCategoryButton } from '../TaskMeasurementCategoryButton';
 
 const useStyles = createStyles((theme) => ({
@@ -39,9 +39,15 @@ const useStyles = createStyles((theme) => ({
 
 type Props = {
   taskGroups: TaskGroup[];
+  tasksRecording: TaskRecording[];
+  setTasksRecording: (tasksRecording: TaskRecording[]) => void;
 };
 
-export const SideBar: FC<Props> = ({ taskGroups }) => {
+export const SideBar: FC<Props> = ({
+  taskGroups,
+  tasksRecording,
+  setTasksRecording,
+}) => {
   const { classes, theme } = useStyles();
   const [opened, setOpened] = useState<Record<string, boolean>>({});
   const ChevronIcon = theme.dir === 'ltr' ? IconChevronDown : IconChevronUp;
@@ -87,6 +93,8 @@ export const SideBar: FC<Props> = ({ taskGroups }) => {
                     groupId={group.id}
                     categoryId={category.id}
                     name={category.name}
+                    tasksRecroding={tasksRecording}
+                    setTasksRecording={setTasksRecording}
                   />
                 ))}
               </Group>

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -93,7 +93,7 @@ export const SideBar: FC<Props> = ({
                     groupId={group.id}
                     categoryId={category.id}
                     name={category.name}
-                    tasksRecroding={tasksRecording}
+                    tasksRecording={tasksRecording}
                     setTasksRecording={setTasksRecording}
                   />
                 ))}

--- a/src/components/TaskMeasurementCategoryButton/TaskMeasurementCategoryButton.tsx
+++ b/src/components/TaskMeasurementCategoryButton/TaskMeasurementCategoryButton.tsx
@@ -31,7 +31,7 @@ type Props = {
   groupId: number;
   categoryId: number;
   name: string;
-  tasksRecroding: TaskRecording[];
+  tasksRecording: TaskRecording[];
   setTasksRecording: (tasksRecording: TaskRecording[]) => void;
 };
 
@@ -39,7 +39,7 @@ export const TaskMeasurementCategoryButton: FC<Props> = ({
   groupId,
   categoryId,
   name,
-  tasksRecroding,
+  tasksRecording,
   setTasksRecording,
 }) => {
   const { classes, theme } = useStyles();
@@ -51,7 +51,7 @@ export const TaskMeasurementCategoryButton: FC<Props> = ({
       taskCategoryId: categoryId,
       status: 'recording',
     });
-    setTasksRecording([...tasksRecroding, createdTask]);
+    setTasksRecording([...tasksRecording, createdTask]);
   };
 
   return (

--- a/src/components/TaskMeasurementCategoryButton/TaskMeasurementCategoryButton.tsx
+++ b/src/components/TaskMeasurementCategoryButton/TaskMeasurementCategoryButton.tsx
@@ -4,6 +4,7 @@ import { useHover } from '@mantine/hooks';
 import { IconHome } from '@tabler/icons-react';
 import Image from 'next/image';
 import { createTask } from '@/api/client/fetch/task';
+import type { TaskRecording } from '@/features';
 import hoveredImageSrc from './hover.webp';
 
 const useStyles = createStyles((theme) => ({
@@ -30,12 +31,16 @@ type Props = {
   groupId: number;
   categoryId: number;
   name: string;
+  tasksRecroding: TaskRecording[];
+  setTasksRecording: (tasksRecording: TaskRecording[]) => void;
 };
 
 export const TaskMeasurementCategoryButton: FC<Props> = ({
   groupId,
   categoryId,
   name,
+  tasksRecroding,
+  setTasksRecording,
 }) => {
   const { classes, theme } = useStyles();
   const { hovered, ref } = useHover();
@@ -46,7 +51,7 @@ export const TaskMeasurementCategoryButton: FC<Props> = ({
       taskCategoryId: categoryId,
       status: 'recording',
     });
-    console.log(createdTask); // TODO Issue 126で UI に反映する
+    setTasksRecording([...tasksRecroding, createdTask]);
   };
 
   return (

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -15,6 +15,7 @@ export { isAccount } from './account';
 export type { Account, CreateAccount, FindAccount } from './account';
 export {
   isTask,
+  isRecordingTask,
   isRecordingTasks,
   isPendingTasks,
   isNextApiRequestBodyOfCreateTaskDto,

--- a/src/features/task/index.ts
+++ b/src/features/task/index.ts
@@ -1,5 +1,6 @@
 export {
   isTask,
+  isRecordingTask,
   isRecordingTasks,
   isPendingTasks,
   isNextApiRequestBodyOfStartTaskDto,

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -141,10 +141,10 @@ export const isNextApiRequestBodyOfCompleteTaskDto = (
 ): value is NextApiRequestBodyOfCompleteTaskDto => {
   return nextApiRequestBodyOfCompleteTaskDtoSchema.safeParse(value).success;
 };
-export type CreateTask = (dto: CreateTaskDto) => Promise<Task>;
+export type CreateTask = (dto: CreateTaskDto) => Promise<TaskRecording>;
 export type CreateTaskFromClient = (
   dto: CreateTaskDtoFromClient
-) => Promise<Task>;
+) => Promise<TaskRecording>;
 export type StartTask = (dto: StartTaskDto) => Promise<Task>;
 export type StartTaskFromClient = (
   dto: StartTaskDtoFromClient

--- a/src/features/task/task.ts
+++ b/src/features/task/task.ts
@@ -115,6 +115,12 @@ export const isTask = (value: unknown): value is Task => {
   return result.success;
 };
 
+export const isRecordingTask = (value: unknown): value is TaskRecording => {
+  const result = taskRecordingSchema.safeParse(value);
+
+  return result.success;
+};
+
 export const isRecordingTasks = (value: unknown): value is TaskRecording[] => {
   return tasksRecordingSchema.safeParse(value).success;
 };

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -4,12 +4,14 @@ import Head from 'next/head';
 import { signOut } from 'next-auth/react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { TitleText, HeaderNavigation, SideBar } from '@/components';
-import type { TaskGroup } from '@/features';
+import type { TaskGroup, TaskRecording } from '@/features';
 import { ErrorFallback } from '@/components/ErrorFallback/ErrorFallback';
 
 type Props = {
   children: ReactNode;
   taskGroups: TaskGroup[];
+  tasksRecording: TaskRecording[];
+  setTasksRecording: (tasksRecording: TaskRecording[]) => void;
 };
 
 const onError = (error: Error, info: { componentStack: string }) => {
@@ -37,7 +39,12 @@ const handleLogout = async (event: MouseEvent<HTMLButtonElement>) => {
 };
 
 // eslint-disable-next-line max-lines-per-function
-export const DefaultLayout: FC<Props> = ({ children, taskGroups }) => {
+export const DefaultLayout: FC<Props> = ({
+  children,
+  taskGroups,
+  tasksRecording,
+  setTasksRecording,
+}) => {
   const { classes } = useStyles();
 
   return (
@@ -52,7 +59,11 @@ export const DefaultLayout: FC<Props> = ({ children, taskGroups }) => {
       <HeaderNavigation handleLogout={handleLogout}></HeaderNavigation>
       <Container size="xl">
         <div className={classes.layoutWrapper}>
-          <SideBar taskGroups={taskGroups} />
+          <SideBar
+            taskGroups={taskGroups}
+            tasksRecording={tasksRecording}
+            setTasksRecording={setTasksRecording}
+          />
           <div className={classes.mainContent}>
             <TitleText title={title} />
             <ErrorBoundary FallbackComponent={ErrorFallback} onError={onError}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,12 @@ type Props = {
 
 const IndexPage: NextPage<Props> = ({ taskGroups }) => {
   return (
-    <DefaultLayout taskGroups={taskGroups}>
+    <DefaultLayout
+      taskGroups={taskGroups}
+      // FIXME 今回の変更でVercelデプロイ時にエラーが出るため、一旦空配列を渡す（本来は不要なので対策を講じる必要がある）
+      tasksRecording={[]}
+      setTasksRecording={() => []}
+    >
       <a href="https://github.com/commew/timelogger-web/issues/91">
         TODO 91のissue
       </a>

--- a/src/pages/timer.tsx
+++ b/src/pages/timer.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { NextPage, GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import {
@@ -21,9 +22,13 @@ const TimerPage: NextPage<Props> = ({
   pendingTasks,
   taskGroups,
 }) => {
+  const [initialTasksRecording, setInitialTasksRecording] =
+    useState<TaskRecording[]>(tasksRecording);
+
   return (
     <TimerTemplate
-      tasksRecording={tasksRecording}
+      tasksRecording={initialTasksRecording}
+      setTasksRecording={setInitialTasksRecording}
       pendingTasks={pendingTasks}
       taskGroups={taskGroups}
     />

--- a/src/templates/TimerTemplate/TimerTemplate.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.tsx
@@ -28,12 +28,14 @@ const useStyles = createStyles((theme) => ({
 
 type Props = {
   tasksRecording: TaskRecording[];
+  setTasksRecording: (tasksRecording: TaskRecording[]) => void;
   pendingTasks: PendingTask[];
   taskGroups: TaskGroup[];
 };
 
 export const TimerTemplate: FC<Props> = ({
   tasksRecording,
+  setTasksRecording,
   pendingTasks,
   taskGroups,
 }) => {
@@ -61,7 +63,11 @@ export const TimerTemplate: FC<Props> = ({
   };
 
   return (
-    <DefaultLayout taskGroups={taskGroups}>
+    <DefaultLayout
+      taskGroups={taskGroups}
+      tasksRecording={tasksRecording}
+      setTasksRecording={setTasksRecording}
+    >
       <Title order={2} className={classes.measuringHead} mt={'2rem'}>
         <IconPlayerPlay
           size="1.25rem"


### PR DESCRIPTION
# issueURL

#118 

# この PR で対応する範囲 / この PR で対応しない範囲

- createTask(新規タスクの計測開始)の実行結果をUIに反映する処理を実装する
- その他のUI反映は別ブランチで対応する（実装方針の相談を先にしておきたいため）

# Storybook の URL、 スクリーンショット

![Oct-06-2023 10-47-16](https://github.com/commew/timelogger-web/assets/9443634/769dcbca-e4f7-4ac5-8aed-a54c3fb688f5)

# 変更点概要

タスク計測開始メニューを押下すると、記録中のタスク一覧にレスポンスデータを追加されるよう実装しました。
これに伴い、getServerSidePropsで受け取っていた計測中のタスク一覧を useState を経由して子コンポーネントにPropsとして受け渡す形にしています。

また、一部のTaskに関する型情報を修正しています。
実装の意図など詳しくはレビュー依頼にて記載させていただきます🙇

# レビュアーに重点的にチェックして欲しい点

ソースコードに記載いたします。

# 補足情報

とくになし