### PR TITLE
ヘッダーナビゲーションから計測以外のリンクを削除した

### DIFF
--- a/src/components/HeaderNavigation/HeaderNavigation.tsx
+++ b/src/components/HeaderNavigation/HeaderNavigation.tsx
@@ -50,27 +50,6 @@ export const HeaderNavigation: FC<Props> = ({ handleLogout }) => {
               </Link>
             </Menu.Target>
           </Menu>
-          <Menu>
-            <Menu.Target>
-              <Link href={'/'} className={classes.link}>
-                集計
-              </Link>
-            </Menu.Target>
-          </Menu>
-          <Menu>
-            <Menu.Target>
-              <Link href={'/'} className={classes.link}>
-                タスク履歴
-              </Link>
-            </Menu.Target>
-          </Menu>
-          <Menu>
-            <Menu.Target>
-              <Link href={'/'} className={classes.link}>
-                各種設定
-              </Link>
-            </Menu.Target>
-          </Menu>
         </Group>
         <Group position="right" ml={'auto'}>
           <Button

--- a/src/components/HeaderNavigation/__tests__/HeaderNavigation.spec.tsx
+++ b/src/components/HeaderNavigation/__tests__/HeaderNavigation.spec.tsx
@@ -25,7 +25,7 @@ describe('src/components/HeaderNavigation/HeaderNavigation.tsx TestCases', () =>
     const handleLogout = jest.fn();
     renderWithTheme(<HeaderNavigation handleLogout={handleLogout} />);
 
-    const linkLabels = ['計測', '集計', 'タスク履歴', '各種設定'];
+    const linkLabels = ['計測'];
     linkLabels.forEach((label) => {
       expect(screen.getByText(label)).toBeTruthy();
     });


### PR DESCRIPTION
# issueURL

#124 

# この PR で対応する範囲 / この PR で対応しない範囲

- ヘッダーナビゲーションにベタ書きされていたリンクの内、「計測」以外を削除した

# Storybook の URL、 スクリーンショット

ベタ書きのコードを削除しただけなので、スクショのみです
![image](https://github.com/commew/timelogger-web/assets/9443634/3d33865a-6431-459e-9d81-7cfc4a7767cc)

# 変更点概要

掲題の通りです、`features/url`も一応見ましたが、削除対象のパスは設定されていなかったのでHeaderNavigationのコード削除だけで問題ない認識です。

# レビュアーに重点的にチェックして欲しい点

今回は特に問題となる変更はありません！

# 補足情報

とくになし