### PR TITLE
ページ内の見出しに適切な文言が入るように調整を行った

### DIFF
--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -9,6 +9,7 @@ import { ErrorFallback } from '@/components/ErrorFallback/ErrorFallback';
 
 type Props = {
   children: ReactNode;
+  title: string;
   taskGroups: TaskGroup[];
   handleCreateTask: HandleCreateTask;
 };
@@ -18,8 +19,6 @@ const onError = (error: Error, info: { componentStack: string }) => {
   console.log('error.message', error.message);
   console.log('info.componentStack:', info.componentStack);
 };
-
-const title = 'Time Logger（仮）';
 
 const useStyles = createStyles(() => ({
   layoutWrapper: {
@@ -40,6 +39,7 @@ const handleLogout = async (event: MouseEvent<HTMLButtonElement>) => {
 // eslint-disable-next-line max-lines-per-function
 export const DefaultLayout: FC<Props> = ({
   children,
+  title,
   taskGroups,
   handleCreateTask,
 }) => {

--- a/src/pages/timer.tsx
+++ b/src/pages/timer.tsx
@@ -33,6 +33,7 @@ const TimerPage: NextPage<Props> = ({
 
   return (
     <TimerTemplate
+      title={'計測'}
       tasksRecording={initialRecordingTasks}
       pendingTasks={initialPendingTasks}
       handleCreateTask={handleCreateTask}

--- a/src/templates/TimerTemplate/TimerTemplate.stories.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.stories.tsx
@@ -68,6 +68,7 @@ const taskGroups = [
 
 export const Default: Story = {
   args: {
+    title: '計測',
     tasksRecording: [
       {
         id: 1,
@@ -132,6 +133,7 @@ export const Default: Story = {
 
 export const NoTasks: Story = {
   args: {
+    title: '計測',
     tasksRecording: [],
     pendingTasks: [],
     taskGroups,

--- a/src/templates/TimerTemplate/TimerTemplate.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.tsx
@@ -31,6 +31,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 type Props = {
+  title: string;
   tasksRecording: TaskRecording[];
   handleCreateTask: HandleCreateTask;
   handleStartTask: HandleStartTask;
@@ -41,6 +42,7 @@ type Props = {
 };
 
 export const TimerTemplate: FC<Props> = ({
+  title,
   tasksRecording,
   handleCreateTask,
   handleStartTask,
@@ -73,7 +75,11 @@ export const TimerTemplate: FC<Props> = ({
   };
 
   return (
-    <DefaultLayout taskGroups={taskGroups} handleCreateTask={handleCreateTask}>
+    <DefaultLayout
+      title={title}
+      taskGroups={taskGroups}
+      handleCreateTask={handleCreateTask}
+    >
       <Title order={2} className={classes.measuringHead} mt={'2rem'}>
         <IconPlayerPlay
           size="1.25rem"


### PR DESCRIPTION
# issueURL

#122 

# この PR で対応する範囲 / この PR で対応しない範囲

- DefaultLayout でtitleを受け取れるようにした
- 計測ページのtitleを設定し、DefaultLayoutにPropsとして渡せるようにした
- 計測ページのStorybookのargsにもtitleを設定した

# Storybook の URL、 スクリーンショット

https://63d52217f1430a5ad69846cd-irtqdeawyc.chromatic.com/?path=/story/templates-timertemplate--default

# 変更点概要

ページ内の見出しに適切な文言が入るように調整を行いました。
計測ページの見出しはFigmaに合わせました。
FIgma: https://www.figma.com/file/Mowdr0KHcHfm2bmi7pfg75/UI%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E8%B3%87%E6%96%99?type=design&node-id=258-90026&mode=design&t=42bVz7ZyNQcrSiop-0

#122 の補足事項にも記載いただいていましたように、今後の拡張性を考慮し、DefaultLayoutでPropsとしてtitleを受け取れるようにしています。

# レビュアーに重点的にチェックして欲しい点

計測ページについては、 pages/Timer.tsx から TimerTemplate -> DefaultLayout とtitleを受け渡しております。
（Pageコンポーネントではなく、TimerTemplateから直接titleで渡しても良いかと思いましたが、実装者が何かしら改修する際はおそらくpages起点でコードを読むと思ったのでpagesから受け渡すようにしました。）

# 補足情報

とくになし