### PR TITLE
TaskItemでtaskIdをPropsで受け取れるように修正した

### DIFF
--- a/src/components/TaskItem/TaskItem.stories.tsx
+++ b/src/components/TaskItem/TaskItem.stories.tsx
@@ -16,6 +16,7 @@ type Story = ComponentStoryObj<typeof TaskItem>;
 
 export const Default: Story = {
   args: {
+    taskId: 1,
     categoryName: 'カテゴリ名',
     categoryGroupName: 'グループ名',
     duration: 14400,
@@ -25,6 +26,7 @@ export const Default: Story = {
 
 export const Pending: Story = {
   args: {
+    taskId: 1,
     categoryName: 'カテゴリ名',
     categoryGroupName: 'グループ名',
     duration: 14400,

--- a/src/components/TaskItem/TaskItem.tsx
+++ b/src/components/TaskItem/TaskItem.tsx
@@ -31,6 +31,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 type Props = {
+  taskId: number;
   categoryName: string;
   categoryGroupName: string;
   duration: number;
@@ -41,6 +42,7 @@ type Props = {
 };
 
 export const TaskItem: FC<Props> = ({
+  taskId,
   categoryName,
   categoryGroupName,
   duration,
@@ -56,9 +58,13 @@ export const TaskItem: FC<Props> = ({
   const renderChangeStatusButton = () => {
     switch (status) {
       case 'recording':
-        return <StopTaskButton taskId={1} handleStopTask={handleStopTask} />;
+        return (
+          <StopTaskButton taskId={taskId} handleStopTask={handleStopTask} />
+        );
       case 'pending':
-        return <StartTaskButton taskId={1} handleStartTask={handleStartTask} />;
+        return (
+          <StartTaskButton taskId={taskId} handleStartTask={handleStartTask} />
+        );
       case 'completed':
         return;
       default:
@@ -97,7 +103,7 @@ export const TaskItem: FC<Props> = ({
       <Group style={{ alignSelf: 'flex-end' }}>
         {renderChangeStatusButton()}
         <CompleteTaskButton
-          taskId={1}
+          taskId={taskId}
           handleCompleteTask={handleCompleteTask}
         />
       </Group>

--- a/src/templates/TimerTemplate/TimerTemplate.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.tsx
@@ -94,6 +94,7 @@ export const TimerTemplate: FC<Props> = ({
             return (
               <TaskItem
                 key={index}
+                taskId={taskRecording.id}
                 categoryName={
                   getTaskCategoryName(taskRecording.taskCategoryId) ?? ''
                 }
@@ -127,6 +128,7 @@ export const TimerTemplate: FC<Props> = ({
             return (
               <TaskItem
                 key={index}
+                taskId={pendingTask.id}
                 categoryName={
                   getTaskCategoryName(pendingTask.taskCategoryId) ?? ''
                 }


### PR DESCRIPTION
# issueURL

#139 

# この PR で対応する範囲 / この PR で対応しない範囲

- TaskItem で taskId を Props で受け取れるように修正した
- TaskItem で呼び出している、タスク再開・停止処理などを司るボタンコンポーネントに、Props で受け取った taskId を渡すように修正した

# Storybook の URL、 スクリーンショット

UIの変更ではないため、スクショ等はなしです。

# 変更点概要

TimerTemplate から TaskItem に taskId を Props として受け渡せるようにしています。

# レビュアーに重点的にチェックして欲しい点

とくになし

# 補足情報

とくになし