### PR TITLE
バックエンドのAPIが完成したので NEXT_PUBLIC_DEBUG_MOCK_API の条件分岐を削除

### DIFF
--- a/src/api/server/fetch/account.ts
+++ b/src/api/server/fetch/account.ts
@@ -22,9 +22,6 @@ export const createAccount: CreateAccount = async (dto) => {
     headers: {
       Authorization: `Basic ${createBackendApiBasicAuthCredential()}`,
       'Content-Type': 'application/json',
-      // TODO APIのDEBUGを行う時は環境変数に NEXT_PUBLIC_DEBUG_MOCK_API=1 を設定してPreferを書き換える
-      // TODO Preferは https://github.com/commew/timelogger-web/issues/77 で削除する
-      Prefer: 'code=201, example=ExampleSuccess',
     },
     body: JSON.stringify(requestBody),
   });
@@ -56,9 +53,6 @@ export const findAccount: FindAccount = async (dto) => {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${appToken}`,
-      // TODO APIのDEBUGを行う時は環境変数に NEXT_PUBLIC_DEBUG_MOCK_API=1 を設定してPreferを書き換える
-      // TODO Preferは https://github.com/commew/timelogger-web/issues/77 で削除する
-      Prefer: 'code=401,example=ExampleAuthenticated',
     },
   });
 

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -47,15 +47,12 @@ export const authOptions: NextAuthOptions = {
           String(process.env.NEXTAUTH_SECRET)
         );
 
-        // TODO APIが完成したらこの条件分岐を削除する、対応issueは https://github.com/commew/timelogger-web/issues/77
-        if (process.env.NEXT_PUBLIC_DEBUG_MOCK_API === '1') {
-          const account = await findAccount({ appToken: session.appToken });
-          if (account === null) {
-            await createAccount({
-              sub: token.sub,
-              oidcProvider: token.provider,
-            });
-          }
+        const account = await findAccount({ appToken: session.appToken });
+        if (account === null) {
+          await createAccount({
+            sub: token.sub,
+            oidcProvider: token.provider,
+          });
         }
       }
 


### PR DESCRIPTION
# issueURL

https://github.com/commew/timelogger-web/issues/77

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/commew/timelogger-web/issues/77 の完了の定義を満たす `NEXT_PUBLIC_DEBUG_MOCK_API ` に関する条件分岐を削除します。

それ以外の対応はこのPRでは実施しません。

# Storybook の URL、 スクリーンショット

## タスクの記録でエラーが発生する

<img width="708" alt="スクリーンショット 2023-10-21 1 01 57" src="https://github.com/commew/timelogger-web/assets/11032365/d4379e7f-88c3-4976-ad0a-0a34905d8a2d">

# 変更点概要

タイトルの通りです。APIの環境が完成したようなので、Vercel上の環境変数（`BACKEND_API_BASE_URL`）も含めて https://commew.slack.com/archives/C02JQQU4VLY/p1697705273062939 で共有された内容に変更してあります。

ローカルで確認しましたがログインは出来るが、タスクの作成で500エラーが返ってくるという状況です。

この500エラーの原因はバックエンド側の `POST /tasks` のステータスコードが200とAPI仕様書と異なっているためです。

https://timmew.commew.net/docs/api#/operations/postTasks

@HaruyaFujimoto @HAYASHI-Masayuki 共有しておきます。

# レビュアーに重点的にチェックして欲しい点

おそらく問題ないかと思いますが、軽く確認をお願いします🙏

# 補足情報

特になし