### PR TITLE
タスクカテゴリ・グループのデータの状態によってはタスク一覧(トップページ)で落ちることがある問題を修正

### DIFF
--- a/src/templates/TimerTemplate/TimerTemplate.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.tsx
@@ -5,6 +5,7 @@ import { useErrorHandler } from 'react-error-boundary';
 import { TaskItem } from '@/components';
 import {
   findTaskCategoryById,
+  findTaskGroupById,
   type HandleStartTask,
   type HandleCreateTask,
   type HandleCompleteTask,
@@ -56,7 +57,7 @@ export const TimerTemplate: FC<Props> = ({
 
   const getTaskGroupName = (taskGroupId: number) => {
     try {
-      const taskGroup = findTaskCategoryById(taskGroups, taskGroupId);
+      const taskGroup = findTaskGroupById(taskGroups, taskGroupId);
 
       return taskGroup.name;
     } catch (error) {


### PR DESCRIPTION
# issueURL

#143 

# この PR で対応する範囲 / この PR で対応しない範囲

- 掲題の件の問題を修正する

# Storybook の URL、 スクリーンショット

正しく読み込めるようになったタスク一覧（トップページ）
![image](https://github.com/commew/timelogger-web/assets/9443634/32939d06-ba3e-4688-9633-3e2fdfb9d5b5)

# 変更点概要

`getTaskGroupName`で`findTaskCategoryById`を使っているのがバグの原因でした。
`findTaskGroupById`を使用することで問題を修正しました。

# レビュアーに重点的にチェックして欲しい点

修正のコード数自体は少ないので、検証環境で問題が修正されたことを念の為ご確認いただきたいです。

# 補足情報

とくになし