### PR TITLE
タスクの表示内容がほかのタスクの内容と混ざることがある問題を修正した

### DIFF
--- a/src/hooks/useTask/useTask.ts
+++ b/src/hooks/useTask/useTask.ts
@@ -34,7 +34,10 @@ export const useTask: UseTask = (
       status,
     });
 
-    setRecordingTasks([...recordingTasks, createdTask]);
+    setRecordingTasks((currentRecordingTasks) => [
+      ...currentRecordingTasks,
+      createdTask,
+    ]);
   };
 
   const handleStartTask: HandleStartTask = async (dto) => {
@@ -44,8 +47,13 @@ export const useTask: UseTask = (
       taskId,
     });
 
-    setRecordingTasks([...recordingTasks, startedTask]);
-    setPendingTasks(pendingTasks.filter((task) => task.id !== startedTask.id));
+    setRecordingTasks((currentRecordingTasks) => [
+      ...currentRecordingTasks,
+      startedTask,
+    ]);
+    setPendingTasks((currentPendingTasks) =>
+      currentPendingTasks.filter((task) => task.id !== startedTask.id)
+    );
   };
 
   const handleStopTask: HandleStopTask = async (dto) => {
@@ -55,10 +63,13 @@ export const useTask: UseTask = (
       taskId,
     });
 
-    setRecordingTasks(
-      initialRecordingTasks.filter((task) => task.id !== stoppedTask.id)
+    setRecordingTasks((currentRecordingTasks) =>
+      currentRecordingTasks.filter((task) => task.id !== stoppedTask.id)
     );
-    setPendingTasks([...initialPendingTasks, stoppedTask]);
+    setPendingTasks((currentPendingTasks) => [
+      ...currentPendingTasks,
+      stoppedTask,
+    ]);
   };
 
   const handleCompleteTask: HandleCompleteTask = async (dto) => {
@@ -68,11 +79,11 @@ export const useTask: UseTask = (
       taskId,
     });
 
-    setPendingTasks(
-      initialPendingTasks.filter((task) => task.id !== completedTask.id)
+    setPendingTasks((currentPendingTasks) =>
+      currentPendingTasks.filter((task) => task.id !== completedTask.id)
     );
-    setRecordingTasks(
-      initialRecordingTasks.filter((task) => task.id !== completedTask.id)
+    setRecordingTasks((currentRecordingTasks) =>
+      currentRecordingTasks.filter((task) => task.id !== completedTask.id)
     );
   };
 

--- a/src/templates/TimerTemplate/TimerTemplate.tsx
+++ b/src/templates/TimerTemplate/TimerTemplate.tsx
@@ -91,10 +91,10 @@ export const TimerTemplate: FC<Props> = ({
       </Title>
       <Stack mt={'1rem'}>
         {tasksRecording.length > 0 ? (
-          tasksRecording.map((taskRecording, index) => {
+          tasksRecording.map((taskRecording) => {
             return (
               <TaskItem
-                key={index}
+                key={taskRecording.id}
                 taskId={taskRecording.id}
                 categoryName={
                   getTaskCategoryName(taskRecording.taskCategoryId) ?? ''
@@ -125,10 +125,10 @@ export const TimerTemplate: FC<Props> = ({
       </Title>
       <Stack mt={'1rem'}>
         {pendingTasks.length > 0 ? (
-          pendingTasks.map((pendingTask, index) => {
+          pendingTasks.map((pendingTask) => {
             return (
               <TaskItem
-                key={index}
+                key={pendingTask.id}
                 taskId={pendingTask.id}
                 categoryName={
                   getTaskCategoryName(pendingTask.taskCategoryId) ?? ''


### PR DESCRIPTION
# issueURL

#141 

# この PR で対応する範囲 / この PR で対応しない範囲

- 掲題の件の問題を修正する

# Storybook の URL、 スクリーンショット

- 一連のタスク操作
![Oct-23-2023 18-19-57](https://github.com/commew/timelogger-web/assets/9443634/6b7a9341-a0b2-4b3c-8121-85b92b8abfc0)

# 変更点概要

- `TaskItem`コンポーネントの`key`に`index`ではなく`taskId`を使用するように修正
- `useTask`の中で`setXXX`のような状態を更新する関数の引数にタスクの配列を直接セットするのではなく、更新関数を適用  


# レビュアーに重点的にチェックして欲しい点

下記URLでログインできるようにしたのですが、Next.js内のクライアント→バックエンドのAPIリクエストでCORSエラーが出てしまうので、一旦スクリーンショットのGIFとコードをご覧いただいて、レビューをお願いします🙇
https://timelogger-web-git-feature-issue143-commew.vercel.app

- CORSエラー内容
バックエンドのエンドポイントが今回のデプロイ分ではなく、 https://timelogger-web-git-feature-issue11add-docs-commew.vercel.app/api/tasks/create になってしまっているみたいです。
```
Access to fetch at 'https://timelogger-web-git-feature-issue11add-docs-commew.vercel.app/api/tasks/create' from origin 'https://timelogger-web-git-feature-issue143-commew.vercel.app' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```

# 補足情報
- 今回のバグの要因について（`useState`の仕様）
以下の公式ドキュメントに記載がありました。今回のバグの原因は、**非同期通信の処理が完了する前に状態を更新してしまっていた**という事象が関連している可能性が非常に高いです。  
useStateで定義する`setXXX`の引数に更新関数としてコールバック関数を与えると、必ず最新の状態を参照して状態を更新できるみたいです。知らなかった・・・
https://ja.react.dev/reference/react/useState#updating-state-based-on-the-previous-state

（`TaskItem`のkeyにindexを使っていたのも悪手でしたね...。主にこの２点がご報告いただいたバグの原因でした。）