### PR TITLE
Preview環境の CORS エラーを解消

### DIFF
--- a/src/features/url/url.ts
+++ b/src/features/url/url.ts
@@ -84,11 +84,7 @@ const appApiPaths: AppApiPaths = {
 type AppApiPathName = keyof AppApiPaths;
 type AppApiPath = (typeof appApiPaths)[keyof typeof appApiPaths];
 
-export const getAppApiUrl = (
-  path: AppApiPathName
-): `${AppUrl}${AppApiPath}` => {
-  const apiUrl = appUrl();
-
+export const getAppApiUrl = (path: AppApiPathName): `${AppApiPath}` => {
   switch (path) {
     case 'tasks':
     case 'startTask':
@@ -96,7 +92,7 @@ export const getAppApiUrl = (
     case 'completeTask': {
       const apiPath: AppApiPath = appApiPaths[path];
 
-      return `${apiUrl}${apiPath}`;
+      return `${apiPath}`;
     }
 
     default:


### PR DESCRIPTION
# issueURL

#146 

# この PR で対応する範囲 / この PR で対応しない範囲

- Preview 環境で CORS エラーが起きる問題を修正するために、API Routeへのアクセスパスを変更する

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

API Routeへのアクセスパスを`NEXT_PUBLIC_APP_URL`を参照せず、`/api/tasks/create` のようにパスのみでアクセスできるようにしました。

# レビュアーに重点的にチェックして欲しい点

`NEXT_PUBLIC_APP_URL` を変更しない状態で、本ブランチのPreview環境でタスクの操作ができることをご確認いただきたいです。
- 本ブランチのPreview環境: https://timelogger-web-git-feature-issue146-commew.vercel.app


# 補足情報

とくになし
